### PR TITLE
Fix missing 404 template error

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}404 - 页面不存在{% endblock %}
+{% block page_title %}404 错误{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-center h-full">
+    <div class="text-center">
+        <div class="mb-8">
+            <svg class="mx-auto h-32 w-32 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+        </div>
+        <h1 class="text-6xl font-bold text-gray-900 mb-4">404</h1>
+        <h2 class="text-2xl font-semibold text-gray-700 mb-4">页面不存在</h2>
+        <p class="text-gray-600 mb-8">抱歉，您访问的页面不存在或已被移除。</p>
+        <div class="space-x-4">
+            <a href="/" class="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a2 2 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                </svg>
+                返回首页
+            </a>
+            <button onclick="history.back()" class="inline-flex items-center px-6 py-3 bg-gray-200 text-gray-700 font-medium rounded-lg hover:bg-gray-300 transition-colors">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+                </svg>
+                返回上一页
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}500 - 服务器错误{% endblock %}
+{% block page_title %}500 错误{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-center h-full">
+    <div class="text-center">
+        <div class="mb-8">
+            <svg class="mx-auto h-32 w-32 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+            </svg>
+        </div>
+        <h1 class="text-6xl font-bold text-gray-900 mb-4">500</h1>
+        <h2 class="text-2xl font-semibold text-gray-700 mb-4">服务器内部错误</h2>
+        <p class="text-gray-600 mb-8">抱歉，服务器遇到了一些问题，请稍后再试。</p>
+        <div class="space-x-4">
+            <a href="/" class="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a2 2 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                </svg>
+                返回首页
+            </a>
+            <button onclick="location.reload()" class="inline-flex items-center px-6 py-3 bg-gray-200 text-gray-700 font-medium rounded-lg hover:bg-gray-300 transition-colors">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                </svg>
+                刷新页面
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
The application was attempting to render 404.html and 500.html templates in the error handlers (app.py:534, app.py:542), but these templates did not exist in the templates directory, causing a Jinja2 TemplateNotFound error.

Created both error page templates with proper styling that extends the base.html layout and follows the existing design system.

Fixes the jinja2.exceptions.TemplateNotFound: 404.htm error.

