### PR TITLE
Update changelog for version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2025-11-26
+
+### Fixed
+- Added missing 404.html and 500.html error page templates for better error handling
+
+## [1.1.0] - 2025-11-26
+
+### Added
+- System publish feature for git commit and push functionality
+- Visual status indicators for post publication state
+- Bulk publishing operations for managing multiple posts
+- Markdown preview functionality in the editor
+- Documentation site configuration with MkDocs
+
+### Changed
+- Optimized preview functionality
+- Improved Socket.IO connection port handling
+- Enhanced posts.html bulk operation toolbar layout
+
+### Fixed
+- Fixed tags and categories displaying as 0 in the dashboard
+- Fixed Socket.IO connection port issues
+
 ## [1.0.1] - 2025-11-26
 
 ### Added

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __version_info__ = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
- Update version from 1.1.0 to 1.1.1
- Add changelog entry for v1.1.1 documenting the addition of 404.html and 500.html error page templates
- Also backfill v1.1.0 changelog with previously unreleased features

