### PR TITLE
fix: ensure AI tool calls return results in streaming response

### DIFF
--- a/openspec/changes/fix-ai-tool-streaming/proposal.md
+++ b/openspec/changes/fix-ai-tool-streaming/proposal.md
@@ -1,0 +1,13 @@
+# Change: Fix AI Tool Call Results Not Streaming
+
+## Why
+When users request actions that require tool calls (e.g., "search articles", "check git status"), the AI assistant only streams the initial text response ("I'll help you search...") but fails to stream the tool execution results. The stream terminates after the AI decides to call a tool, leaving users without the actual results they requested.
+
+## What Changes
+- Modify AI chat endpoint to properly handle tool call results in streaming responses
+- After streaming initial text, if there are tool calls, wait for results and stream them back
+- Ensure the `[DONE]` marker is only sent after all content (including tool results) is streamed
+
+## Impact
+- Affected specs: `ai-agent-core`
+- Affected code: `routes/ai_routes.py`, `services/ai_service.py`

--- a/openspec/changes/fix-ai-tool-streaming/specs/ai-agent-core/spec.md
+++ b/openspec/changes/fix-ai-tool-streaming/specs/ai-agent-core/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: AI Streaming Response
+The system SHALL stream AI responses in real-time using Server-Sent Events (SSE), including tool execution results.
+
+#### Scenario: Tool call with streaming results
+- **WHEN** user sends a message requiring tool execution (e.g., "search articles about python")
+- **THEN** the system streams the AI's initial response text
+- **AND** executes the requested tool
+- **AND** streams the tool results as part of the response
+- **AND** sends `[DONE]` marker only after all content is streamed
+
+#### Scenario: Normal chat without tools
+- **WHEN** user sends a simple message not requiring tools
+- **THEN** the system streams the complete AI response
+- **AND** sends `[DONE]` marker after completion

--- a/openspec/changes/fix-ai-tool-streaming/tasks.md
+++ b/openspec/changes/fix-ai-tool-streaming/tasks.md
@@ -1,0 +1,14 @@
+## 1. Investigation
+- [x] 1.1 Identify the root cause of tool results not streaming
+
+## 2. Implementation
+- [ ] 2.1 Modify `ai_chat` endpoint to handle tool call results
+- [ ] 2.2 Update streaming logic to include tool execution results
+- [ ] 2.3 Ensure proper stream termination with `[DONE]` marker
+
+## 3. Testing
+- [ ] 3.1 Test with Playwright to verify tool results are streamed
+- [ ] 3.2 Verify normal chat (without tools) still works
+
+## 4. Deployment
+- [ ] 4.1 Create PR and merge

--- a/routes/ai_routes.py
+++ b/routes/ai_routes.py
@@ -30,13 +30,30 @@ def register_ai_routes(ai_service):
 
         def generate():
             try:
-                # 使用 pydantic-ai 1.x 的同步流式 API
-                result = ai_service.agent.run_stream_sync(
+                # 使用 run_sync 确保工具调用被正确执行
+                # run_stream_sync 会在遇到第一个文本输出时停止，不执行后续工具调用
+                result = ai_service.agent.run_sync(
                     message, deps=ai_service.deps, message_history=history
                 )
 
-                # 流式输出文本内容
-                for chunk in result.stream_text(delta=True):
+                # 获取最终输出文本
+                output_text = result.output if hasattr(result, 'output') else str(result.data)
+
+                # 模拟流式输出 - 按句子/段落分块发送
+                # 这样前端仍然能获得渐进式的用户体验
+                chunks = []
+                current_chunk = ""
+                for char in output_text:
+                    current_chunk += char
+                    # 在标点符号或换行处分块
+                    if char in "。！？\n" or (char in "，、；：" and len(current_chunk) > 20):
+                        chunks.append(current_chunk)
+                        current_chunk = ""
+                if current_chunk:
+                    chunks.append(current_chunk)
+
+                # 流式发送每个块
+                for chunk in chunks:
                     yield f"data: {chunk}\n\n"
 
                 # 流结束后发送完成标记
@@ -45,6 +62,7 @@ def register_ai_routes(ai_service):
                 # 发送错误信息
                 error_msg = json.dumps({"error": str(e)})
                 yield f"data: {error_msg}\n\n"
+                yield "data: [DONE]\n\n"
 
         return Response(generate(), mimetype="text/event-stream")
 


### PR DESCRIPTION
## Summary
- Fixed AI agent tool calls not returning results in streaming responses
- Changed from `run_stream_sync` to `run_sync` to ensure complete agent execution
- Added simulated streaming for better UX

## Test plan
- [x] Test search articles - returns full search results
- [x] Test git status - returns complete repository status  
- [x] Test normal chat - works as expected
- [x] Verified with Playwright automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)