### PR TITLE
ci: add linting and modernize CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,52 +5,73 @@ on:
     branches: [ master, main, develop ]
     paths:
       - '**.py'
-      - 'requirements*.txt'
+      - 'pyproject.toml'
+      - 'uv.lock'
       - 'pytest.ini'
       - '.github/workflows/test.yml'
   pull_request:
     branches: [ master, main, develop ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Install dependencies
+      run: uv sync --dev
+
+    - name: Run flake8
+      run: uv run flake8 .
+
+    - name: Run black check
+      run: uv run black --check .
+
   test:
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       matrix:
-        # Python 3.9 removed: pydantic-ai>=1.0.0 requires Python 3.10+
-        # Python 3.9 EOL: October 2025
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Cache pip packages
-      uses: actions/cache@v3
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Cache uv packages
+      uses: actions/cache@v4
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+        path: ~/.cache/uv
+        key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-uv-${{ matrix.python-version }}-
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+      run: uv sync --dev
 
     - name: Run tests with pytest
-      run: |
-        pytest tests/ -v --tb=short
+      run: uv run pytest tests/ -v --tb=short
 
     - name: Run tests with coverage
-      run: |
-        pytest tests/ --cov=. --cov-report=xml --cov-report=term
+      run: uv run pytest tests/ --cov=. --cov-report=xml --cov-report=term
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
## Summary

- Add `lint` job with flake8 syntax checking and black format verification
- Modernize CI to use `uv` package manager instead of pip
- Update all GitHub Actions to latest versions

## Changes

### New Lint Job
- Runs flake8 for Python syntax/style checking
- Runs `black --check` for code formatting verification
- Tests only run after linting passes

### Modernized Dependencies
- Use `astral-sh/setup-uv@v4` for uv installation
- Replace `pip install -r requirements-dev.txt` with `uv sync --dev`
- Update cache to use `~/.cache/uv` with `uv.lock` hash

### Updated Actions
- `actions/checkout@v3` → `v4`
- `actions/setup-python@v4` → `v5`
- `actions/cache@v3` → `v4`
- `codecov/codecov-action@v3` → `v4`

## Testing

This PR updates CI configuration. The workflow will validate itself on this PR.