### PR TITLE
fix(editor): restore ordered list numbering in markdown preview

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -89,6 +89,14 @@
         padding-left: 2em;
     }
 
+    .markdown-body ul {
+        list-style-type: disc;
+    }
+
+    .markdown-body ol {
+        list-style-type: decimal;
+    }
+
     .markdown-body li {
         margin-top: 0.25em;
     }

--- a/tests/test_editor_markdown_preview.py
+++ b/tests/test_editor_markdown_preview.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_editor_preview_uses_decimal_ordered_list_markers():
+    template_path = Path(__file__).parent.parent / "templates" / "editor.html"
+    html = template_path.read_text(encoding="utf-8")
+
+    assert ".markdown-body ol {" in html
+    assert "list-style-type: decimal;" in html


### PR DESCRIPTION
## Summary
- Explicitly restore list marker styles in the editor Markdown preview so ordered lists display decimal numbering correctly.
- Keep unordered lists explicit as disc to avoid base CSS resets impacting preview rendering.
- Add a regression test that verifies editor.html includes the ordered-list style rule.

## Testing
- pytest tests/test_editor_markdown_preview.py

Closes #16