### PR TITLE
fix(ci): resolve black check failure in Tests workflow

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -292,7 +292,9 @@ class EmailService:
             normalized = re.sub(pattern, replacement, normalized)
 
         # 兼容 `{{ .TrackLink "..." }}` -> `{{ TrackLink "..." }}`
-        normalized = re.sub(r"{{\s*\.TrackLink(\s+[^}]*)}}", r"{{ TrackLink\1}}", normalized)
+        normalized = re.sub(
+            r"{{\s*\.TrackLink(\s+[^}]*)}}", r"{{ TrackLink\1}}", normalized
+        )
         return normalized
 
     def preview_email(self, post):


### PR DESCRIPTION
## Summary
- Reformat `services/email_service.py` with Black to match project formatting rules.
- Fix the `Run black check` failure in the `Tests` GitHub Actions workflow after the previous merge.

## Verification
- `uv run flake8 . --exclude=.venv,.git,site,.pytest_cache,.ruff_cache`
- `uv run black --check . --exclude='/(\.venv|\.git|site|\.pytest_cache|\.ruff_cache)/'`
- `pytest tests/test_editor_markdown_preview.py`