### PR TITLE
fix(ui): restore sidebar settings button click handler

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -253,7 +253,7 @@
                 <button
                     type="button"
                     class="nav-item w-full text-left bg-transparent border-0 cursor-pointer"
-                    @click="window.dispatchEvent(new CustomEvent('open-settings'))"
+                    onclick="window.dispatchEvent(new CustomEvent('open-settings'))"
                 >
                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>


### PR DESCRIPTION
## Summary
- Fix sidebar `设置` button click handling so it works outside Alpine `x-data` scope.
- Replace Alpine `@click` on the nav button with native `onclick` to dispatch the same `open-settings` custom event.
- Keep existing settings panel behavior unchanged (only trigger wiring updated).

## Testing
- `.venv/bin/pytest tests/test_settings_api.py tests/test_settings_service.py`