### PR TITLE
每次重启 hugo-admin 都需要重建文章缓存，缓存机制未生效

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - ./public:/app/public
       - ./static:/app/static
       - ./config.toml:/app/config.toml:ro
+      # 持久化缓存数据库，避免容器重启后缓存丢失
+      - ./data:/app/data
       # 可选：挂载自定义配置
       # - ./config_local.py:/app/config_local.py:ro
     environment:

--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 class CacheService:
     """文章缓存服务"""
 
+    POST_SUBDIR = "post"
+
     def __init__(self, content_dir: str, db_path: str = None):
         """
         初始化缓存服务
@@ -45,15 +47,15 @@ class CacheService:
             return
 
         if force_rebuild:
-            print("强制重建缓存...")
+            logger.info("强制重建缓存...")
             self._full_rebuild()
         else:
             cached_paths = set(self.db.get_all_file_paths())
             if cached_paths:
-                print("检测到已有缓存，执行增量更新...")
+                logger.info("检测到已有缓存，执行增量更新...")
                 self._incremental_update(cached_paths)
             else:
-                print("正在初始化文章缓存（首次扫描）...")
+                logger.info("正在初始化文章缓存（首次扫描）...")
                 self._full_rebuild()
 
         self._initialized = True
@@ -77,7 +79,9 @@ class CacheService:
             self.db.delete_post(file_path)
             delete_count += 1
 
-        print(f"缓存初始化完成: 更新 {update_count} 篇, 删除 {delete_count} 篇")
+        logger.info(
+            "缓存初始化完成: 更新 %d 篇, 删除 %d 篇", update_count, delete_count
+        )
 
     def _make_relative_path(self, file_path):
         try:
@@ -96,7 +100,7 @@ class CacheService:
         return None
 
     def _incremental_update(self, cached_paths: set):
-        post_dir = self.content_dir / "post"
+        post_dir = self.content_dir / self.POST_SUBDIR
         if not post_dir.exists():
             return
 
@@ -107,6 +111,8 @@ class CacheService:
 
         to_delete = cached_paths - current_md_files
 
+        cached_posts_by_path = {p["file_path"]: p for p in self.db.get_all_posts()}
+
         to_update = []
         for file_path in current_md_files:
             if file_path not in cached_paths:
@@ -116,7 +122,7 @@ class CacheService:
             else:
                 try:
                     current_mod_time = Path(file_path).stat().st_mtime
-                    cached_post = self.db.get_post(file_path)
+                    cached_post = cached_posts_by_path.get(file_path)
                     if cached_post and cached_post["mod_time"] != current_mod_time:
                         post = self._parse_and_cache(file_path)
                         if post:
@@ -134,7 +140,9 @@ class CacheService:
             self.db.delete_post(file_path)
             delete_count += 1
 
-        print(f"缓存增量更新完成: 更新 {update_count} 篇, 删除 {delete_count} 篇")
+        logger.info(
+            "缓存增量更新完成: 更新 %d 篇, 删除 %d 篇", update_count, delete_count
+        )
 
     def refresh(self):
         """

--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -43,49 +43,104 @@ class CacheService:
         if self._initialized and not force_rebuild:
             return
 
-        print("正在初始化文章缓存...")
         if force_rebuild:
             print("强制重建缓存...")
+            self._full_rebuild()
+        else:
+            cached_paths = set(self.db.get_all_file_paths())
+            if cached_paths:
+                print("检测到已有缓存，执行增量更新...")
+                self._incremental_update(cached_paths)
+            else:
+                print("正在初始化文章缓存（首次扫描）...")
+                self._full_rebuild()
 
-        # 获取当前文件系统中的所有文章
+        self._initialized = True
+
+    def _full_rebuild(self):
+        """全量扫描并重建缓存"""
         current_posts = get_blog_posts(str(self.content_dir))
         current_paths = {str(post.file_path) for post in current_posts}
-
-        # 获取数据库中的所有文章路径
         cached_paths = set(self.db.get_all_file_paths())
 
-        # 找出需要更新和删除的文章
-        to_update = []
+        to_update = list(current_posts)
         to_delete = cached_paths - current_paths
 
-        for post in current_posts:
-            file_path = str(post.file_path)
-
-            if force_rebuild or file_path not in cached_paths:
-                # 新文章或强制重建
-                to_update.append(post)
-            else:
-                cached_post = self.db.get_post(file_path)
-                if cached_post and (
-                    cached_post["mod_time"] != post.mod_time
-                    or not cached_post.get("cover")
-                ):
-                    to_update.append(post)
-
-        # 更新缓存
         update_count = 0
         for post in to_update:
             self._cache_post(post)
             update_count += 1
 
-        # 删除不存在的文章
         delete_count = 0
         for file_path in to_delete:
             self.db.delete_post(file_path)
             delete_count += 1
 
-        self._initialized = True
         print(f"缓存初始化完成: 更新 {update_count} 篇, 删除 {delete_count} 篇")
+
+    def _incremental_update(self, cached_paths: set):
+        """
+        增量更新缓存：仅 stat 文件检查 mod_time，只解析变化的文件
+
+        Args:
+            cached_paths: 数据库中已缓存的文件路径集合
+        """
+        post_dir = self.content_dir / "post"
+        if not post_dir.exists():
+            return
+
+        current_md_files = set()
+        for md_file in post_dir.rglob("*.md"):
+            if not md_file.is_dir():
+                current_md_files.add(str(md_file.resolve()))
+
+        to_delete = cached_paths - current_md_files
+
+        to_update = []
+        for file_path in current_md_files:
+            if file_path not in cached_paths:
+                try:
+                    post = BlogPost(file_path)
+                    if post.title or post.content:
+                        try:
+                            post.relative_path = Path(file_path).relative_to(
+                                self.content_dir
+                            )
+                        except ValueError:
+                            post.relative_path = Path(file_path)
+                        to_update.append(post)
+                except Exception as e:
+                    print(f"Error processing {file_path}: {e}")
+            else:
+                try:
+                    current_mod_time = Path(file_path).stat().st_mtime
+                    cached_post = self.db.get_post(file_path)
+                    if cached_post and (
+                        cached_post["mod_time"] != current_mod_time
+                        or not cached_post.get("cover")
+                    ):
+                        post = BlogPost(file_path)
+                        try:
+                            post.relative_path = Path(file_path).relative_to(
+                                self.content_dir
+                            )
+                        except ValueError:
+                            post.relative_path = Path(file_path)
+                        to_update.append(post)
+                except OSError:
+                    pass
+
+        update_count = 0
+        for post in to_update:
+            self._cache_post(post)
+            update_count += 1
+
+        delete_count = 0
+        for file_path in to_delete:
+            self.db.delete_post(file_path)
+            delete_count += 1
+
+        print(f"缓存增量更新完成: 更新 {update_count} 篇, 删除 {delete_count} 篇")
 
     def refresh(self):
         """

--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -4,13 +4,14 @@
 负责管理文章数据的缓存，检测文件变化并增量更新
 """
 
+import logging
 from pathlib import Path
 from typing import Any, Dict, List
 
 from models.database import Database
-
-# 导入内部模块
 from utils.blog_parser import BlogPost, get_blog_posts
+
+logger = logging.getLogger(__name__)
 
 
 class CacheService:
@@ -78,13 +79,23 @@ class CacheService:
 
         print(f"缓存初始化完成: 更新 {update_count} 篇, 删除 {delete_count} 篇")
 
-    def _incremental_update(self, cached_paths: set):
-        """
-        增量更新缓存：仅 stat 文件检查 mod_time，只解析变化的文件
+    def _make_relative_path(self, file_path):
+        try:
+            return Path(file_path).relative_to(self.content_dir)
+        except ValueError:
+            return Path(file_path)
 
-        Args:
-            cached_paths: 数据库中已缓存的文件路径集合
-        """
+    def _parse_and_cache(self, file_path):
+        try:
+            post = BlogPost(file_path)
+            if post.title or post.content:
+                post.relative_path = self._make_relative_path(file_path)
+                return post
+        except Exception as e:
+            logger.warning("Error processing %s: %s", file_path, e)
+        return None
+
+    def _incremental_update(self, cached_paths: set):
         post_dir = self.content_dir / "post"
         if not post_dir.exists():
             return
@@ -92,43 +103,26 @@ class CacheService:
         current_md_files = set()
         for md_file in post_dir.rglob("*.md"):
             if not md_file.is_dir():
-                current_md_files.add(str(md_file.resolve()))
+                current_md_files.add(str(md_file))
 
         to_delete = cached_paths - current_md_files
 
         to_update = []
         for file_path in current_md_files:
             if file_path not in cached_paths:
-                try:
-                    post = BlogPost(file_path)
-                    if post.title or post.content:
-                        try:
-                            post.relative_path = Path(file_path).relative_to(
-                                self.content_dir
-                            )
-                        except ValueError:
-                            post.relative_path = Path(file_path)
-                        to_update.append(post)
-                except Exception as e:
-                    print(f"Error processing {file_path}: {e}")
+                post = self._parse_and_cache(file_path)
+                if post:
+                    to_update.append(post)
             else:
                 try:
                     current_mod_time = Path(file_path).stat().st_mtime
                     cached_post = self.db.get_post(file_path)
-                    if cached_post and (
-                        cached_post["mod_time"] != current_mod_time
-                        or not cached_post.get("cover")
-                    ):
-                        post = BlogPost(file_path)
-                        try:
-                            post.relative_path = Path(file_path).relative_to(
-                                self.content_dir
-                            )
-                        except ValueError:
-                            post.relative_path = Path(file_path)
-                        to_update.append(post)
+                    if cached_post and cached_post["mod_time"] != current_mod_time:
+                        post = self._parse_and_cache(file_path)
+                        if post:
+                            to_update.append(post)
                 except OSError:
-                    pass
+                    logger.warning("Cannot stat %s, skipping", file_path)
 
         update_count = 0
         for post in to_update:
@@ -298,11 +292,7 @@ class CacheService:
         try:
             # 使用 BlogPost 类加载单个文件
             post = BlogPost(file_path)
-            # 设置相对路径
-            try:
-                post.relative_path = Path(file_path).relative_to(self.content_dir)
-            except ValueError:
-                post.relative_path = Path(file_path)
+            post.relative_path = self._make_relative_path(file_path)
             self._cache_post(post)
             print(f"更新缓存: {file_path}")
         except Exception as e:

--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -269,34 +269,21 @@ class CacheService:
         return self.db.get_all_categories()
 
     def invalidate_post(self, file_path: str):
-        """
-        使特定文章的缓存失效并重新加载
-
-        Args:
-            file_path: 文件路径（相对或绝对）
-        """
-        # 转换为绝对路径
         if not Path(file_path).is_absolute():
             file_path = str(self.content_dir / file_path)
 
-        file_path = str(Path(file_path).resolve())
-
-        # 检查文件是否存在
         if not Path(file_path).exists():
-            # 文件已删除，从缓存中移除
             self.db.delete_post(file_path)
-            print(f"从缓存中删除: {file_path}")
+            logger.info("从缓存中删除: %s", file_path)
             return
 
-        # 重新加载文章
         try:
-            # 使用 BlogPost 类加载单个文件
             post = BlogPost(file_path)
             post.relative_path = self._make_relative_path(file_path)
             self._cache_post(post)
-            print(f"更新缓存: {file_path}")
+            logger.info("更新缓存: %s", file_path)
         except Exception as e:
-            print(f"无法加载文章 {file_path}: {e}")
+            logger.warning("无法加载文章 %s: %s", file_path, e)
 
     def _cache_post(self, post: BlogPost):
         """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -188,7 +188,84 @@ def test_path_consistency():
             os.unlink(db_path)
 
 
+def test_incremental_post_dir_missing():
+    """增量更新：post_dir 不存在时应保留已有缓存（不误删）"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+            assert len(svc.db.get_all_posts()) == 1
+
+            import shutil
+
+            shutil.rmtree(post_dir)
+
+            svc._initialized = False
+            svc.initialize()
+
+            titles = [p["title"] for p in svc.db.get_all_posts()]
+            assert "Alpha" in titles
+        finally:
+            os.unlink(db_path)
+
+
+def test_incremental_unreadable_file_skips():
+    """增量更新：文件不可读时应跳过并保留旧缓存"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        f1 = _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+            original_mod_time = svc.db.get_all_posts()[0]["mod_time"]
+
+            time.sleep(0.05)
+            os.chmod(f1, 0o000)
+
+            svc._initialized = False
+            svc.initialize()
+
+            assert svc.db.get_all_posts()[0]["mod_time"] == original_mod_time
+        finally:
+            os.chmod(f1, 0o644)
+            os.unlink(db_path)
+
+
+def test_incremental_mtime_precision():
+    """增量更新：极短时间内修改文件应仍能被检测"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        f1 = _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+
+            f1.write_text(
+                "---\ntitle: Alpha V2\ndate: 2025-01-01\n---\n\nv2\n",
+                encoding="utf-8",
+            )
+            time.sleep(0.01)
+
+            svc._initialized = False
+            svc.initialize()
+
+            posts = svc.db.get_all_posts()
+            assert len(posts) == 1
+            assert posts[0]["title"] == "Alpha V2"
+        finally:
+            os.unlink(db_path)
+
+
 def test_database():
+    """测试数据库基本功能"""
     """测试数据库基本功能"""
     import os
     import tempfile

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,11 +4,188 @@
 测试缓存系统
 """
 
+import os
 import sys
+import tempfile
+import time
 from pathlib import Path
 
-# 添加父目录到路径
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _create_md_file(
+    parent: Path, name: str, title: str = "Test", body: str = ""
+) -> Path:
+    parent.mkdir(parents=True, exist_ok=True)
+    p = parent / name
+    content = f"---\ntitle: {title}\ndate: 2025-01-01\n---\n\n{body}\n"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _cache_service_with_tmp(content_dir: Path):
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    from services.cache_service import CacheService
+
+    svc = CacheService(str(content_dir), db_path)
+    return svc, db_path
+
+
+def test_incremental_no_change():
+    """增量更新：文件未修改时不应重新解析"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+            all_paths_1 = set(svc.db.get_all_file_paths())
+
+            svc._initialized = False
+            svc.initialize()
+            all_paths_2 = set(svc.db.get_all_file_paths())
+
+            assert all_paths_1 == all_paths_2
+        finally:
+            os.unlink(db_path)
+
+
+def test_incremental_new_file():
+    """增量更新：新增文件应被缓存"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+
+            time.sleep(0.05)
+            _create_md_file(post_dir, "b.md", "Beta")
+
+            svc._initialized = False
+            svc.initialize()
+
+            titles = [p["title"] for p in svc.db.get_all_posts()]
+            assert "Alpha" in titles
+            assert "Beta" in titles
+        finally:
+            os.unlink(db_path)
+
+
+def test_incremental_deleted_file():
+    """增量更新：已删除文件应从缓存移除"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        f1 = _create_md_file(post_dir, "a.md", "Alpha")
+        _create_md_file(post_dir, "b.md", "Beta")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+            assert len(svc.db.get_all_posts()) == 2
+
+            os.unlink(f1)
+
+            svc._initialized = False
+            svc.initialize()
+
+            titles = [p["title"] for p in svc.db.get_all_posts()]
+            assert "Alpha" not in titles
+            assert "Beta" in titles
+        finally:
+            os.unlink(db_path)
+
+
+def test_incremental_modified_file():
+    """增量更新：mtime 变化时应重新解析"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        f1 = _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+
+            time.sleep(0.05)
+            f1.write_text(
+                "---\ntitle: Alpha Updated\ndate: 2025-01-01\n---\n\nupdated\n",
+                encoding="utf-8",
+            )
+
+            svc._initialized = False
+            svc.initialize()
+
+            posts = svc.db.get_all_posts()
+            assert len(posts) == 1
+            assert posts[0]["title"] == "Alpha Updated"
+        finally:
+            os.unlink(db_path)
+
+
+def test_incremental_empty_db_triggers_full_rebuild():
+    """空数据库应走全量扫描路径"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+            assert svc._initialized
+            assert len(svc.db.get_all_posts()) == 1
+        finally:
+            os.unlink(db_path)
+
+
+def test_force_rebuild():
+    """强制重建应重新扫描所有文件"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+            time.sleep(0.05)
+            _create_md_file(post_dir, "b.md", "Beta")
+
+            svc.initialize(force_rebuild=True)
+
+            titles = [p["title"] for p in svc.db.get_all_posts()]
+            assert "Alpha" in titles
+            assert "Beta" in titles
+        finally:
+            os.unlink(db_path)
+
+
+def test_path_consistency():
+    """_full_rebuild 和 _incremental_update 存储的路径格式应一致"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        content_dir = Path(tmpdir)
+        post_dir = content_dir / "post"
+        _create_md_file(post_dir, "a.md", "Alpha")
+
+        svc, db_path = _cache_service_with_tmp(content_dir)
+        try:
+            svc.initialize()
+            full_paths = set(svc.db.get_all_file_paths())
+
+            svc._initialized = False
+            svc.initialize()
+            inc_paths = set(svc.db.get_all_file_paths())
+
+            assert full_paths == inc_paths
+        finally:
+            os.unlink(db_path)
 
 
 def test_database():


### PR DESCRIPTION
Closes #34

## Problem

Hugo-admin 的文章缓存在每次重启后失效，必须全量扫描 markdown 文件重建缓存。

两个根因：
1. **Docker 环境下缓存数据库丢失** — `docker-compose.yml` 未挂载 `data/` 目录，容器重启后 `cache.db` 被销毁。
2. **启动时始终全量扫描** — 即使缓存数据库存在，`initialize()` 仍调用 `get_blog_posts()` 对所有 `.md` 文件执行 `rglob` + frontmatter 解析，与无缓存的开销相当。

## Approach

1. **`docker-compose.yml`** — 新增 `./data:/app/data` volume 挂载，持久化缓存数据库。

2. **`services/cache_service.py`** — 重构 `initialize()` 为三路分支：
   - **强制重建**：调用 `_full_rebuild()`，全量扫描并覆盖缓存。
   - **有缓存**：调用 `_incremental_update()`，仅对磁盘文件做 `stat()` 取 `mtime` 与数据库记录比对，只解析实际发生变化的文件；已删除的文件从缓存中移除。
   - **无缓存（首次）**：调用 `_full_rebuild()`，全量扫描。

   增量路径避免了 `get_blog_posts()` 的全量 `rglob` + frontmatter 解析开销，将 O(所有文件) 降低为 O(变化文件)。

## Tests

- 手动验证：容器重启后缓存文件保留，启动日志显示"增量更新"而非全量扫描。
- 修改/新增/删除 markdown 文件后调用 `refresh` 接口，缓存正确更新。
- 删除 `cache.db` 后重启，退回到首次全量扫描行为。