### PR TITLE
fix: Hugo server baseURL 硬编码导致 Docker 环境预览不可用

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN mkdir -p /app/content /app/public /app/static /app/templates
 
 # 暴露端口
 EXPOSE 5050
+EXPOSE 1313
 
 # 健康检查
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/config.py
+++ b/config.py
@@ -24,7 +24,7 @@ class Config:
     # Hugo 配置
     HUGO_SERVER_HOST = "0.0.0.0"
     HUGO_SERVER_PORT = 1313
-    HUGO_SERVER_BASE_URL = "http://192.168.2.14"
+    HUGO_SERVER_BASE_URL = os.environ.get("HUGO_SERVER_BASE_URL", "http://192.168.2.14")
 
     # 文件上传配置
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB

--- a/config.py
+++ b/config.py
@@ -24,7 +24,7 @@ class Config:
     # Hugo 配置
     HUGO_SERVER_HOST = "0.0.0.0"
     HUGO_SERVER_PORT = 1313
-    HUGO_SERVER_BASE_URL = os.environ.get("HUGO_SERVER_BASE_URL", "http://192.168.2.14")
+    HUGO_SERVER_BASE_URL = os.environ.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313")
 
     # 文件上传配置
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - HUGO_ROOT=/app
       - CONTENT_DIR=/app/content
       - PUBLIC_DIR=/app/public
+      - HUGO_SERVER_BASE_URL=${HUGO_SERVER_BASE_URL:-http://localhost:1313}
     restart: unless-stopped
     networks:
       - hugo-network

--- a/services/hugo_service.py
+++ b/services/hugo_service.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import psutil
 
+from config import Config
+
 
 class HugoServerManager:
     """Hugo 服务器管理器"""
@@ -55,7 +57,7 @@ class HugoServerManager:
                 "server",
                 "--bind=0.0.0.0",
                 "-b",
-                "http://192.168.2.14",
+                Config.HUGO_SERVER_BASE_URL,
                 "--disableFastRender",
             ]
             if debug:


### PR DESCRIPTION
## Summary

- Fixes #37
- `config.py`: `HUGO_SERVER_BASE_URL` 支持通过环境变量 `HUGO_SERVER_BASE_URL` 覆盖，Docker 默认值改为 `http://localhost:1313`
- `hugo_service.py`: 从 `Config.HUGO_SERVER_BASE_URL` 读取 baseURL，移除硬编码的 `http://192.168.2.14`
- `Dockerfile`: 补充 `EXPOSE 1313`
- `docker-compose.yml`: 新增 `HUGO_SERVER_BASE_URL` 环境变量配置

## Test

本地开发通过 `config_local.py` 覆盖不受影响，Docker 环境使用环境变量默认值。