### PR TITLE
fix: 防止 Ctrl+V 粘贴图片时重复插入

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -741,61 +741,84 @@ function editor() {
         },
 
         async handlePaste(event) {
+            // 防止重复处理（事件监听器重复绑定或快速触发）
+            if (this._isPasting) {
+                event.preventDefault();
+                return;
+            }
+
             // 检查剪贴板中是否有图片
             const items = event.clipboardData?.items;
             if (!items) return;
 
+            // 先检查是否包含图片，提前阻止默认粘贴行为
             let hasImage = false;
             for (let i = 0; i < items.length; i++) {
-                const item = items[i];
-
-                // 检查是否为图片类型
-                if (item.type.indexOf('image') !== -1) {
+                if (items[i].type.indexOf('image') !== -1) {
                     hasImage = true;
-                    event.preventDefault(); // 阻止默认粘贴行为
-
-                    // 获取图片文件
-                    const file = item.getAsFile();
-                    if (!file) continue;
-
-                    // 检查是否有当前文件
-                    if (!this.currentFile) {
-                        utils.showNotification('请先选择或创建一篇文章', 'error');
-                        return;
-                    }
-
-                    // 显示上传提示
-                    utils.showNotification('正在上传图片...', 'info');
-
-                    try {
-                        // 上传图片
-                        const formData = new FormData();
-                        formData.append('file', file, `clipboard-${Date.now()}.png`);
-                        formData.append('article_path', this.currentFile);
-
-                        const response = await fetch('/api/image/upload', {
-                            method: 'POST',
-                            body: formData
-                        });
-
-                        const data = await response.json();
-                        if (data.success) {
-                            // 插入图片 Markdown 语法到光标位置
-                            this.insertImageAtCursor(data.url);
-                            utils.showNotification('图片上传成功', 'success');
-
-                            // 刷新图片列表
-                            await this.loadImages();
-                        } else {
-                            utils.showNotification('图片上传失败: ' + data.message, 'error');
-                        }
-                    } catch (error) {
-                        console.error('Failed to upload image from clipboard:', error);
-                        utils.showNotification('图片上传失败', 'error');
-                    }
-
-                    break; // 只处理第一个图片
+                    break;
                 }
+            }
+
+            if (!hasImage) return;
+
+            // 立即阻止浏览器默认粘贴行为，防止同时插入 base64 图片
+            event.preventDefault();
+            event.stopImmediatePropagation();
+
+            this._isPasting = true;
+
+            try {
+                for (let i = 0; i < items.length; i++) {
+                    const item = items[i];
+
+                    // 检查是否为图片类型
+                    if (item.type.indexOf('image') !== -1) {
+                        // 获取图片文件
+                        const file = item.getAsFile();
+                        if (!file) continue;
+
+                        // 检查是否有当前文件
+                        if (!this.currentFile) {
+                            utils.showNotification('请先选择或创建一篇文章', 'error');
+                            return;
+                        }
+
+                        // 显示上传提示
+                        utils.showNotification('正在上传图片...', 'info');
+
+                        try {
+                            // 上传图片
+                            const formData = new FormData();
+                            formData.append('file', file, `clipboard-${Date.now()}.png`);
+                            formData.append('article_path', this.currentFile);
+
+                            const response = await fetch('/api/image/upload', {
+                                method: 'POST',
+                                body: formData
+                            });
+
+                            const data = await response.json();
+                            if (data.success) {
+                                // 插入图片 Markdown 语法到光标位置
+                                this.insertImageAtCursor(data.url);
+                                utils.showNotification('图片上传成功', 'success');
+
+                                // 刷新图片列表
+                                await this.loadImages();
+                            } else {
+                                utils.showNotification('图片上传失败: ' + data.message, 'error');
+                            }
+                        } catch (error) {
+                            console.error('Failed to upload image from clipboard:', error);
+                            utils.showNotification('图片上传失败', 'error');
+                        }
+
+                        break; // 只处理第一个图片
+                    }
+                }
+            } finally {
+                this._isPasting = false;
             }
         },
 

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -764,7 +764,7 @@ function editor() {
 
             // 立即阻止浏览器默认粘贴行为，防止同时插入 base64 图片
             event.preventDefault();
-            event.stopImmediatePropagation();
+            event.stopPropagation();
 
             this._isPasting = true;
 
@@ -781,7 +781,7 @@ function editor() {
                         // 检查是否有当前文件
                         if (!this.currentFile) {
                             utils.showNotification('请先选择或创建一篇文章', 'error');
-                            return;
+                            break;
                         }
 
                         // 显示上传提示
@@ -790,13 +790,18 @@ function editor() {
                         try {
                             // 上传图片
                             const formData = new FormData();
-                            formData.append('file', file, `clipboard-${Date.now()}.png`);
+                            const ext = file.type.split('/')[1] || 'png';
+                            formData.append('file', file, `clipboard-${Date.now()}.${ext}`);
                             formData.append('article_path', this.currentFile);
 
                             const response = await fetch('/api/image/upload', {
                                 method: 'POST',
                                 body: formData
                             });
+
+                            if (!response.ok) {
+                                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                            }
 
                             const data = await response.json();
                             if (data.success) {


### PR DESCRIPTION
## 问题

修复 #42：Ctrl+V 粘贴图片后出现两张图片。

## 原因

`event.preventDefault()` 在 `for` 循环内部调用，是在异步检测到第一个图片 item 时才执行。此时浏览器可能已经执行了默认粘贴行为（将图片以 base64 格式插入 textarea），而代码同时手动插入了 `![](url)` Markdown 语法，导致出现两张图片。

此外，如果 `paste` 事件监听器被重复绑定，或者快速触发，也会导致重复插入。

## 修复内容

1. **提前阻止默认行为**：先扫描剪贴板确认包含图片，然后立即在循环外调用 `event.preventDefault()` 和 `event.stopImmediatePropagation()`
2. **添加并发保护**：引入 `_isPasting` 标志，防止重复处理或并发触发
3. **使用 try/finally 确保状态重置**：即使上传过程中出错，`_isPasting` 标志也会被正确重置

## 测试方式

1. 打开文章编辑器
2. 复制一张图片到剪贴板
3. 按 Ctrl+V 粘贴
4. 验证只插入了一张 `![](url)` Markdown 图片语法

## 改动范围

- `templates/editor.html`：`handlePaste` 方法重构

Fixes #42