### PR TITLE
feat: 隐藏 frontmatter 并添加侧边抽屉编辑

### DIFF
--- a/app.py
+++ b/app.py
@@ -422,17 +422,44 @@ def read_file():
         return jsonify({"success": False, "message": content}), 404
 
 
+@app.route("/api/file/read-with-frontmatter", methods=["POST"])
+def read_file_with_frontmatter():
+    """读取文件内容，分离 frontmatter 和正文"""
+    data = request.get_json()
+    file_path = data.get("path")
+
+    if not file_path:
+        return jsonify({"success": False, "message": "缺少文件路径"}), 400
+
+    success, content, fm = post_service.read_file_with_frontmatter(file_path)
+
+    if success:
+        return jsonify(
+            {
+                "success": True,
+                "content": content,
+                "frontmatter": fm,
+                "path": file_path,
+            }
+        )
+    else:
+        return jsonify({"success": False, "message": content}), 404
+
+
 @app.route("/api/file/save", methods=["POST"])
 def save_file():
     """保存文件内容"""
     data = request.get_json()
     file_path = data.get("path")
     content = data.get("content")
+    frontmatter_data = data.get("frontmatter")
 
     if not file_path or content is None:
         return jsonify({"success": False, "message": "缺少必要参数"}), 400
 
-    success, message = post_service.save_file(file_path, content)
+    success, message = post_service.save_file(
+        file_path, content, frontmatter_data=frontmatter_data
+    )
 
     return jsonify({"success": success, "message": message}), 200 if success else 500
 

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -426,7 +426,12 @@ class PostService:
                 return False, f"文件不存在: {file_path}", {}
 
             post = frontmatter.load(str(file_path))
-            return True, post.content, dict(post.metadata)
+            metadata = {}
+            for k, v in post.metadata.items():
+                metadata[k] = (
+                    str(v) if not isinstance(v, (str, int, float, bool, list)) else v
+                )
+            return True, post.content, metadata
 
         except Exception as e:
             return False, f"读取文件失败: {str(e)}", {}

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -454,7 +454,7 @@ class PostService:
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
-            if frontmatter_data is not None:
+            if frontmatter_data is not None and frontmatter_data:
                 post = frontmatter.Post(content, **frontmatter_data)
                 file_content = frontmatter.dumps(post)
             else:

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -403,34 +403,65 @@ class PostService:
         except Exception as e:
             return False, f"读取文件失败: {str(e)}"
 
-    def save_file(self, file_path, content):
+    def read_file_with_frontmatter(self, file_path):
         """
-        保存文件内容
+        读取文件内容，分离 frontmatter 和正文
 
         Args:
-            file_path: 文件路径
-            content: 文件内容
+            file_path: 文件路径(相对于 content 目录或绝对路径)
 
         Returns:
-            (success, message): 成功标志和消息
+            (success, content, frontmatter): 成功标志、正文内容、frontmatter 字典
         """
         try:
-            # 处理路径
             if not Path(file_path).is_absolute():
                 file_path = self.content_dir / file_path
 
             file_path = Path(file_path)
 
-            # 安全检查
+            if not self._is_safe_path(file_path):
+                return False, "访问被拒绝:文件不在允许的目录中", {}
+
+            if not file_path.exists():
+                return False, f"文件不存在: {file_path}", {}
+
+            post = frontmatter.load(str(file_path))
+            return True, post.content, dict(post.metadata)
+
+        except Exception as e:
+            return False, f"读取文件失败: {str(e)}", {}
+
+    def save_file(self, file_path, content, frontmatter_data=None):
+        """
+        保存文件内容
+
+        Args:
+            file_path: 文件路径
+            content: 文件内容（正文，不含 frontmatter）
+            frontmatter_data: 可选的 frontmatter 字典，传入时与正文合并写入
+
+        Returns:
+            (success, message): 成功标志和消息
+        """
+        try:
+            if not Path(file_path).is_absolute():
+                file_path = self.content_dir / file_path
+
+            file_path = Path(file_path)
+
             if not self._is_safe_path(file_path):
                 return False, "访问被拒绝:文件不在允许的目录中"
 
-            # 确保父目录存在
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # 保存文件
+            if frontmatter_data is not None:
+                post = frontmatter.Post(content, **frontmatter_data)
+                file_content = frontmatter.dumps(post)
+            else:
+                file_content = content
+
             with open(file_path, "w", encoding="utf-8") as f:
-                f.write(content)
+                f.write(file_content)
 
             # 更新缓存
             if self.use_cache and self.cache_service:

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -170,6 +170,52 @@
         border: 0;
     }
 
+    /* Frontmatter 抽屉样式 */
+    .fm-drawer-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.3);
+        z-index: 40;
+    }
+
+    .fm-drawer {
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: 420px;
+        max-width: 90vw;
+        height: 100vh;
+        background: white;
+        box-shadow: -4px 0 20px rgba(0, 0, 0, 0.1);
+        z-index: 50;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .fm-field label {
+        display: block;
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: #4b5563;
+        margin-bottom: 4px;
+    }
+
+    .fm-field input, .fm-field select {
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.375rem;
+        font-size: 0.875rem;
+        outline: none;
+        transition: border-color 0.2s;
+    }
+
+    .fm-field input:focus, .fm-field select:focus {
+        border-color: #3b82f6;
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+
     /* 工具栏按钮样式 */
     .toolbar-btn {
         padding: 0.5rem 1rem;
@@ -206,6 +252,15 @@
             </div>
 
             <div class="flex items-center space-x-2">
+                <!-- Frontmatter 编辑按钮 -->
+                <button @click="showFrontmatterDrawer = true"
+                        class="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                    </svg>
+                    Frontmatter
+                </button>
+
                 <!-- 图片管理按钮 -->
                 <button @click="showImageManager = !showImageManager"
                         class="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center">
@@ -343,6 +398,91 @@
         </div>
     </div>
 
+    <!-- Frontmatter 抽屉 -->
+    <div x-show="showFrontmatterDrawer" x-transition.opacity class="fm-drawer-overlay" @click="showFrontmatterDrawer = false"></div>
+    <div x-show="showFrontmatterDrawer"
+         x-transition:enter="transition transform duration-300"
+         x-transition:enter-start="translate-x-full"
+         x-transition:enter-end="translate-x-0"
+         x-transition:leave="transition transform duration-200"
+         x-transition:leave-start="translate-x-0"
+         x-transition:leave-end="translate-x-full"
+         class="fm-drawer">
+        <!-- 抽屉头部 -->
+        <div class="flex items-center justify-between p-4 border-b">
+            <h3 class="text-lg font-semibold text-gray-900">Frontmatter</h3>
+            <button @click="showFrontmatterDrawer = false" class="text-gray-400 hover:text-gray-600">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+            </button>
+        </div>
+
+        <!-- 抽屉内容 -->
+        <div class="flex-1 overflow-y-auto p-4 space-y-4">
+            <div class="fm-field">
+                <label>title</label>
+                <input type="text" x-model="fmEdit.title" placeholder="文章标题">
+            </div>
+
+            <div class="fm-field">
+                <label>date</label>
+                <input type="text" x-model="fmEdit.date" placeholder="2024-01-01T00:00:00+08:00">
+            </div>
+
+            <div class="fm-field">
+                <label>draft</label>
+                <select x-model="fmEdit.draft">
+                    <option value="true">true (草稿)</option>
+                    <option value="false">false (已发布)</option>
+                </select>
+            </div>
+
+            <div class="fm-field">
+                <label>tags (逗号分隔)</label>
+                <input type="text" x-model="fmTagsStr" placeholder="tag1, tag2">
+            </div>
+
+            <div class="fm-field">
+                <label>categories (逗号分隔)</label>
+                <input type="text" x-model="fmCategoriesStr" placeholder="cat1, cat2">
+            </div>
+
+            <div class="fm-field">
+                <label>cover</label>
+                <input type="text" x-model="fmEdit.cover" placeholder="封面图片路径">
+            </div>
+
+            <div class="fm-field">
+                <label>description</label>
+                <input type="text" x-model="fmEdit.description" placeholder="文章描述">
+            </div>
+
+            <!-- 额外字段 -->
+            <div class="border-t pt-4">
+                <div class="flex items-center justify-between mb-2">
+                    <label class="text-sm font-semibold text-gray-600">其他字段</label>
+                    <button @click="fmExtraFields.push({key: '', value: ''})" class="text-sm text-blue-600 hover:text-blue-700">+ 添加字段</button>
+                </div>
+                <template x-for="(field, i) in fmExtraFields" :key="i">
+                    <div class="flex items-center space-x-2 mb-2">
+                        <input type="text" x-model="field.key" placeholder="key" class="w-1/3 px-2 py-1 border rounded text-sm">
+                        <input type="text" x-model="field.value" placeholder="value" class="flex-1 px-2 py-1 border rounded text-sm">
+                        <button @click="fmExtraFields.splice(i, 1)" class="text-red-400 hover:text-red-600">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                        </button>
+                    </div>
+                </template>
+            </div>
+        </div>
+
+        <!-- 抽屉底部 -->
+        <div class="p-4 border-t flex justify-end space-x-2">
+            <button @click="showFrontmatterDrawer = false" class="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">取消</button>
+            <button @click="applyFrontmatter()" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">应用</button>
+        </div>
+    </div>
+
     <!-- 加载状态 -->
     <template x-if="loading">
         <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -367,6 +507,13 @@ function editor() {
         publishing: false,
         isPublished: false,
         showImageManager: false,
+        showFrontmatterDrawer: false,
+        frontmatter: {},
+        originalFrontmatter: {},
+        fmEdit: {},
+        fmTagsStr: '',
+        fmCategoriesStr: '',
+        fmExtraFields: [],
         images: [],
 
         async init() {
@@ -416,20 +563,74 @@ function editor() {
         },
 
         checkChanges() {
-            this.hasChanges = this.content !== this.originalContent;
+            this.hasChanges = this.content !== this.originalContent
+                || JSON.stringify(this.frontmatter) !== JSON.stringify(this.originalFrontmatter);
+        },
+
+        syncFmEdit() {
+            this.fmEdit = {};
+            const reserved = ['tags', 'categories'];
+            for (const [k, v] of Object.entries(this.frontmatter)) {
+                if (!reserved.includes(k)) {
+                    this.fmEdit[k] = typeof v === 'boolean' ? String(v) : v;
+                }
+            }
+            // Ensure core fields exist
+            if (!this.fmEdit.title) this.fmEdit.title = '';
+            if (!this.fmEdit.date) this.fmEdit.date = '';
+            if (!this.fmEdit.draft) this.fmEdit.draft = 'true';
+            if (!this.fmEdit.cover) this.fmEdit.cover = '';
+            if (!this.fmEdit.description) this.fmEdit.description = '';
+
+            this.fmTagsStr = Array.isArray(this.frontmatter.tags)
+                ? this.frontmatter.tags.join(', ') : (this.frontmatter.tags || '');
+            this.fmCategoriesStr = Array.isArray(this.frontmatter.categories)
+                ? this.frontmatter.categories.join(', ') : (this.frontmatter.categories || '');
+
+            // Collect extra (non-core) fields
+            const coreKeys = ['title', 'date', 'draft', 'tags', 'categories', 'cover', 'description'];
+            this.fmExtraFields = [];
+            for (const [k, v] of Object.entries(this.frontmatter)) {
+                if (!coreKeys.includes(k)) {
+                    this.fmExtraFields.push({ key: k, value: typeof v === 'object' ? JSON.stringify(v) : String(v) });
+                    delete this.fmEdit[k];
+                }
+            }
+        },
+
+        applyFrontmatter() {
+            const fm = {};
+            // Core fields
+            for (const [k, v] of Object.entries(this.fmEdit)) {
+                if (v !== '' && v !== undefined && v !== null) {
+                    if (k === 'draft') {
+                        fm[k] = v === 'true';
+                    } else {
+                        fm[k] = v;
+                    }
+                }
+            }
+            // Tags
+            if (this.fmTagsStr.trim()) {
+                fm.tags = this.fmTagsStr.split(',').map(s => s.trim()).filter(Boolean);
+            }
+            // Categories
+            if (this.fmCategoriesStr.trim()) {
+                fm.categories = this.fmCategoriesStr.split(',').map(s => s.trim()).filter(Boolean);
+            }
+            // Extra fields
+            for (const field of this.fmExtraFields) {
+                if (field.key.trim()) {
+                    fm[field.key.trim()] = field.value;
+                }
+            }
+            this.frontmatter = fm;
+            this.showFrontmatterDrawer = false;
+            this.checkChanges();
         },
 
         updatePreview() {
-            // 移除 frontmatter 部分（用 --- 包围的元数据）
-            let contentWithoutFrontmatter = this.content || '';
-            // 匹配开头的 frontmatter：--- 开始，--- 结束
-            const frontmatterRegex = /^---[\s\S]*?---\s*/;
-            if (frontmatterRegex.test(contentWithoutFrontmatter)) {
-                contentWithoutFrontmatter = contentWithoutFrontmatter.replace(frontmatterRegex, '');
-            }
-
-            // 渲染 Markdown（使用移除 frontmatter 后的内容）
-            let html = marked.parse(contentWithoutFrontmatter);
+            let html = marked.parse(this.content || '');
 
             // 修复图片路径
             if (this.currentFile) {
@@ -513,7 +714,7 @@ function editor() {
         async loadFile() {
             this.loading = true;
             try {
-                const response = await fetch('/api/file/read', {
+                const response = await fetch('/api/file/read-with-frontmatter', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ path: this.currentFile })
@@ -523,10 +724,12 @@ function editor() {
                 if (data.success) {
                     this.content = data.content;
                     this.originalContent = data.content;
+                    this.frontmatter = data.frontmatter || {};
+                    this.originalFrontmatter = JSON.parse(JSON.stringify(this.frontmatter));
+                    this.syncFmEdit();
                     this.updatePreview();
                     this.hasChanges = false;
 
-                    // 加载发布状态
                     await this.checkPublishStatus();
                 } else {
                     utils.showNotification('加载文件失败: ' + data.message, 'error');
@@ -552,13 +755,15 @@ function editor() {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         path: this.currentFile,
-                        content: this.content
+                        content: this.content,
+                        frontmatter: this.frontmatter
                     })
                 });
 
                 const data = await response.json();
                 if (data.success) {
                     this.originalContent = this.content;
+                    this.originalFrontmatter = JSON.parse(JSON.stringify(this.frontmatter));
                     this.hasChanges = false;
                     utils.showNotification('保存成功', 'success');
                 } else {

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -175,7 +175,7 @@
         position: fixed;
         inset: 0;
         background: rgba(0, 0, 0, 0.3);
-        z-index: 40;
+        z-index: 55;
     }
 
     .fm-drawer {
@@ -187,7 +187,7 @@
         height: 100vh;
         background: white;
         box-shadow: -4px 0 20px rgba(0, 0, 0, 0.1);
-        z-index: 50;
+        z-index: 60;
         overflow-y: auto;
         display: flex;
         flex-direction: column;

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -427,7 +427,7 @@
 
             <div class="fm-field">
                 <label>date</label>
-                <input type="text" x-model="fmEdit.date" placeholder="2024-01-01T00:00:00+08:00">
+                <input type="datetime-local" x-model="fmDateLocal" @change="fmEdit.date = fmDateLocal ? fmDateLocal.replace('T', ' ') + ':00+08:00' : ''">
             </div>
 
             <div class="fm-field">
@@ -513,6 +513,7 @@ function editor() {
         fmEdit: {},
         fmTagsStr: '',
         fmCategoriesStr: '',
+        fmDateLocal: '',
         fmExtraFields: [],
         images: [],
 
@@ -586,6 +587,16 @@ function editor() {
                 ? this.frontmatter.tags.join(', ') : (this.frontmatter.tags || '');
             this.fmCategoriesStr = Array.isArray(this.frontmatter.categories)
                 ? this.frontmatter.categories.join(', ') : (this.frontmatter.categories || '');
+
+            // Convert date to datetime-local format (YYYY-MM-DDTHH:MM)
+            this.fmDateLocal = '';
+            if (this.fmEdit.date) {
+                const d = new Date(this.fmEdit.date);
+                if (!isNaN(d.getTime())) {
+                    const pad = n => String(n).padStart(2, '0');
+                    this.fmDateLocal = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+                }
+            }
 
             // Collect extra (non-core) fields
             const coreKeys = ['title', 'date', 'draft', 'tags', 'categories', 'cover', 'description'];

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -722,8 +722,8 @@ function editor() {
 
                 const data = await response.json();
                 if (data.success) {
-                    this.content = data.content;
-                    this.originalContent = data.content;
+                    this.content = data.content || '';
+                    this.originalContent = this.content;
                     this.frontmatter = data.frontmatter || {};
                     this.originalFrontmatter = JSON.parse(JSON.stringify(this.frontmatter));
                     this.syncFmEdit();
@@ -732,7 +732,24 @@ function editor() {
 
                     await this.checkPublishStatus();
                 } else {
-                    utils.showNotification('加载文件失败: ' + data.message, 'error');
+                    // Fallback to old API
+                    const fallbackResp = await fetch('/api/file/read', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ path: this.currentFile })
+                    });
+                    const fallbackData = await fallbackResp.json();
+                    if (fallbackData.success) {
+                        this.content = fallbackData.content || '';
+                        this.originalContent = this.content;
+                        this.frontmatter = {};
+                        this.originalFrontmatter = {};
+                        this.updatePreview();
+                        this.hasChanges = false;
+                        await this.checkPublishStatus();
+                    } else {
+                        utils.showNotification('加载文件失败: ' + data.message, 'error');
+                    }
                 }
             } catch (error) {
                 console.error('Failed to load file:', error);
@@ -756,7 +773,7 @@ function editor() {
                     body: JSON.stringify({
                         path: this.currentFile,
                         content: this.content,
-                        frontmatter: this.frontmatter
+                        ...(Object.keys(this.frontmatter).length > 0 ? { frontmatter: this.frontmatter } : {})
                     })
                 });
 


### PR DESCRIPTION
## Summary

- 后端新增 `/api/file/read-with-frontmatter` 端点，使用 python-frontmatter 库分离返回 frontmatter 和正文
- 后端 `save_file` 支持可选的 `frontmatter` 参数，自动合并写回文件
- 前端编辑器仅显示正文内容，不再显示 YAML frontmatter 头部
- 工具栏新增 "Frontmatter" 按钮，点击弹出右侧抽屉面板
- 抽屉支持编辑 title、date、draft、tags、categories、cover、description 及自定义 key-value 字段

## Test plan

- [x] 61 个现有测试全部通过
- [x] 打开已有文章 → 编辑器中不显示 frontmatter YAML
- [x] 点击工具栏 "Frontmatter" 按钮 → 右侧抽屉滑出，显示表单化的 frontmatter 字段
- [x] 修改 frontmatter 字段并保存 → 文件正确更新
- [x] 修改正文并保存 → 文件正确更新，frontmatter 不丢失
- [x] 新建文章 → 正常工作

Closes #45, Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)