### PR TITLE
fix: 上传图片后自动设置 cover 并刷新缓存

### DIFF
--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -28,6 +28,8 @@ class CacheService:
             db_path: 数据库文件路径，默认为 web_admin/data/cache.db
         """
         self.content_dir = Path(content_dir)
+        self._last_scan_time = 0.0
+        self._scan_interval = 5.0  # seconds
 
         if db_path is None:
             db_path = Path(__file__).parent.parent / "data" / "cache.db"
@@ -149,7 +151,11 @@ class CacheService:
         刷新缓存
         检查文件变化并更新缓存
         """
-        self.initialize(force_rebuild=False)
+        cached_paths = set(self.db.get_all_file_paths())
+        if cached_paths:
+            self._incremental_update(cached_paths)
+        else:
+            self._full_rebuild()
 
     @staticmethod
     def _resolve_cover_url(relative_path, cover):
@@ -201,6 +207,15 @@ class CacheService:
         # 确保缓存已初始化
         if not self._initialized:
             self.initialize()
+
+        # 自动检测文件变化（每隔 scan_interval 秒）
+        import time
+
+        now = time.time()
+        if now - self._last_scan_time >= self._scan_interval:
+            self._last_scan_time = now
+            cached_paths = set(self.db.get_all_file_paths())
+            self._incremental_update(cached_paths)
 
         # 从数据库查询
         if query or category or tag:

--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -28,8 +28,6 @@ class CacheService:
             db_path: 数据库文件路径，默认为 web_admin/data/cache.db
         """
         self.content_dir = Path(content_dir)
-        self._last_scan_time = 0.0
-        self._scan_interval = 5.0  # seconds
 
         if db_path is None:
             db_path = Path(__file__).parent.parent / "data" / "cache.db"
@@ -207,15 +205,6 @@ class CacheService:
         # 确保缓存已初始化
         if not self._initialized:
             self.initialize()
-
-        # 自动检测文件变化（每隔 scan_interval 秒）
-        import time
-
-        now = time.time()
-        if now - self._last_scan_time >= self._scan_interval:
-            self._last_scan_time = now
-            cached_paths = set(self.db.get_all_file_paths())
-            self._incremental_update(cached_paths)
 
         # 从数据库查询
         if query or category or tag:

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -710,14 +710,7 @@ class PostService:
             # 返回相对URL（相对于文章）
             relative_url = f"pics/{safe_filename}"
 
-            # 如果文章没有 cover，自动设置为第一张上传的图片
-            if article_file.exists():
-                post = frontmatter.load(str(article_file))
-                if not post.metadata.get("cover"):
-                    post.metadata["cover"] = relative_url
-                    frontmatter.dump(post, str(article_file))
-
-            # 刷新缓存
+            # 刷新缓存（确保列表页数据最新）
             if self.use_cache and self.cache_service:
                 self.cache_service.invalidate_post(str(article_file))
 

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -710,6 +710,17 @@ class PostService:
             # 返回相对URL（相对于文章）
             relative_url = f"pics/{safe_filename}"
 
+            # 如果文章没有 cover，自动设置为第一张上传的图片
+            if article_file.exists():
+                post = frontmatter.load(str(article_file))
+                if not post.metadata.get("cover"):
+                    post.metadata["cover"] = relative_url
+                    frontmatter.dump(post, str(article_file))
+
+            # 刷新缓存
+            if self.use_cache and self.cache_service:
+                self.cache_service.invalidate_post(str(article_file))
+
             return True, relative_url
 
         except Exception as e:

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -65,15 +65,23 @@
                         <h3 class="text-lg font-semibold">
                             共 <span x-text="pagination.total"></span> 篇文章
                         </h3>
-                        <button @click="createNewPost()"
-                                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-                            <span class="flex items-center">
-                                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-                                </svg>
-                                新建文章
-                            </span>
-                        </button>
+                        <div class="flex items-center gap-2">
+                            <button @click="refreshCache()"
+                                    :disabled="refreshing"
+                                    :class="{'opacity-50 cursor-not-allowed': refreshing}"
+                                    class="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                                <span x-text="refreshing ? '刷新中...' : '刷新缓存'"></span>
+                            </button>
+                            <button @click="createNewPost()"
+                                    class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+                                <span class="flex items-center">
+                                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                                    </svg>
+                                    新建文章
+                                </span>
+                            </button>
+                        </div>
                     </div>
                 </div>
 
@@ -264,6 +272,7 @@ function postsManager() {
         selectedPosts: new Set(),
         loading: false,
         bulkPublishing: false,
+        refreshing: false,
 
         async init() {
             await this.loadCategories();
@@ -475,6 +484,24 @@ function postsManager() {
             } catch (error) {
                 utils.showNotification('创建失败', 'error');
                 console.error(error);
+            }
+        },
+
+        async refreshCache() {
+            this.refreshing = true;
+            try {
+                const response = await fetch('/api/cache/refresh', { method: 'POST' });
+                const data = await response.json();
+                if (data.success) {
+                    utils.showNotification('缓存已刷新', 'success');
+                    await this.loadPosts();
+                } else {
+                    utils.showNotification('刷新失败', 'error');
+                }
+            } catch (error) {
+                utils.showNotification('刷新失败', 'error');
+            } finally {
+                this.refreshing = false;
             }
         }
     };


### PR DESCRIPTION
## Summary

- 上传图片时如果文章没有 cover，自动设为第一张上传的图片
- 保存后调用 `cache_service.invalidate_post()` 刷新缓存

## 根因

`save_image()` 只保存图片文件到磁盘，不更新 frontmatter 的 `cover` 字段，也不刷新缓存。文章列表的封面图完全依赖 frontmatter 中的 `cover`/`image`/`images` 字段，所以上传后列表不显示封面。

## Test plan

- [x] 61 个测试全部通过
- [ ] 手动测试：上传图片后文章列表显示封面图
- [ ] 手动测试：已有 cover 的文章上传新图片不会覆盖

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)