### PR TITLE
fix: 修复编辑器模板 Jinja2 解析 500 错误

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -431,7 +431,7 @@
             <button @click="insertMarkdown('link')" class="toolbar-btn" title="链接">
                 🔗 链接
             </button>
-            <button @click="insertMarkdown('ref')" class="toolbar-btn" title="文章引用 ({{&lt; ref &gt;}})">
+            <button @click="insertMarkdown('ref')" class="toolbar-btn" title="文章引用 ({% raw %}{{< ref >}}{% endraw %})">
                 🔗 引用
             </button>
             <button @click="insertMarkdown('image')" class="toolbar-btn" title="图片">
@@ -627,10 +627,12 @@
     </template>
 </div>
 
+<script>var __filePath = '{% if file_path %}{{ file_path }}{% endif %}';</script>
+{% raw %}
 <script>
 function editor() {
     return {
-        currentFile: '{% if file_path %}{{ file_path }}{% endif %}',
+        currentFile: __filePath,
         content: '',
         originalContent: '',
         preview: '',
@@ -1335,4 +1337,5 @@ function editor() {
     };
 }
 </script>
+{% endraw %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- 编辑器模板中 Hugo shortcode `{{< ref >}}` 的 `{{` 被 Jinja2 误解析为表达式，导致访问编辑器页面 500

## Test plan
- [ ] 访问编辑器页面不再返回 500
- [ ] 工具栏"引用"按钮功能正常
- [ ] `{{< ref >}}` 自动补全功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)