### PR TITLE
fix(backend): auto-append Hugo port when server_url omits it

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request, send_file, send_from_directory
@@ -67,6 +68,22 @@ except ImportError:
     app.config.from_object(DevelopmentConfig)
     print("✓ 已加载默认配置 (config.py)")
 
+
+def _ensure_server_url_has_port(url: str) -> str:
+    """若 URL 已带 scheme 但缺少显式端口，则按 HUGO_SERVER_PORT 补齐。"""
+    if not url:
+        return url
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname or parsed.port is not None:
+        return url
+    default_port = app.config.get("HUGO_SERVER_PORT", 1313)
+    return urlunparse(parsed._replace(netloc=f"{parsed.hostname}:{default_port}"))
+
+
+app.config["HUGO_SERVER_BASE_URL"] = _ensure_server_url_has_port(
+    app.config.get("HUGO_SERVER_BASE_URL", "")
+)
+
 # 向后兼容的配置
 app.config["HUGO_ROOT"] = app.config.get("HUGO_ROOT", Path(__file__).parent.parent)
 app.config["CONTENT_DIR"] = app.config.get(
@@ -93,7 +110,9 @@ try:
     app.config["AI_BASE_URL"] = persisted_settings["ai"]["base_url"]
     app.config["AI_MODEL"] = persisted_settings["ai"]["model"]
     app.config["AI_API_KEY"] = ENV_AI_API_KEY
-    _hugo_server_url = persisted_settings.get("hugo", {}).get("server_url", "")
+    _hugo_server_url = _ensure_server_url_has_port(
+        persisted_settings.get("hugo", {}).get("server_url", "")
+    )
 except (SettingsValidationError, SettingsStorageError) as e:
     print(f"⚠ 设置文件读取失败，继续使用默认配置: {e}")
     _hugo_server_url = ""
@@ -129,9 +148,10 @@ def _to_public_settings(settings):
     public_settings["hugo"]["base_dir"] = public_settings["hugo"]["base_dir"] or str(
         app.config.get("HUGO_ROOT", "")
     )
-    public_settings["hugo"]["server_url"] = public_settings["hugo"].get(
-        "server_url", ""
-    ) or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313")
+    public_settings["hugo"]["server_url"] = _ensure_server_url_has_port(
+        public_settings["hugo"].get("server_url", "")
+        or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313")
+    )
 
     global SESSION_AI_API_KEY
     session_api_key = SESSION_AI_API_KEY
@@ -319,7 +339,9 @@ def update_settings():
     app.config["AI_API_KEY"] = SESSION_AI_API_KEY or ENV_AI_API_KEY
 
     new_hugo_root = updated_settings.get("hugo", {}).get("base_dir", "")
-    new_server_url = updated_settings.get("hugo", {}).get("server_url", "")
+    new_server_url = _ensure_server_url_has_port(
+        updated_settings.get("hugo", {}).get("server_url", "")
+    )
     if new_hugo_root and str(app.config["HUGO_ROOT"]) != new_hugo_root:
         new_root = Path(new_hugo_root)
         app.config["HUGO_ROOT"] = new_root


### PR DESCRIPTION
## Problem

On the Server page, clicking '访问网站' (visit site) jumps to the URL stored in `hugo.server_url`. When that URL has no explicit port (e.g. `http://192.168.2.14` or `config_local.py`'s `HUGO_SERVER_BASE_URL = "http://127.0.0.1"`), the browser hits port 80 and the link fails.

Repro: set Hugo server URL to `http://192.168.2.14` in the Settings page → start Hugo server → click '访问网站' → fails to load.

## Root cause

Three call sites read the URL straight from config or persisted settings, none of which guarantee a port:
- `app.py` startup: `HUGO_SERVER_BASE_URL` from `config_local.py`
- `app.py` runtime: persisted `hugo.server_url` from `.admin/settings.json`
- `app.py` `_to_public_settings()`: returns the same value to the React frontend

## Fix

Add `_ensure_server_url_has_port()` helper using `urllib.parse`. When the URL has a scheme + host but no port, append `HUGO_SERVER_PORT` (default 1313). Apply it at all four touch points:

1. After loading config into `app.config['HUGO_SERVER_BASE_URL']`
2. When reading persisted settings into `_hugo_server_url`
3. When applying updates in `/api/settings/update`
4. When returning settings to the frontend in `_to_public_settings()`

Result: the React Server page always receives an URL with a port, so the '访问网站' link works regardless of whether the user/operator wrote a port in their config.

## Tests

`tests/test_settings_api.py` + `tests/test_settings_service.py`: 17 passed.

Helper behaviour verified with 6 URL variants (with/without scheme/port/path/query/empty).

## Out of scope

`config_local.py` is gitignored so it stays as-is; the fix makes the omission harmless.