### PR TITLE
ci: switch OpenCode review model to deepseek-v4-flash

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
         uses: Svtter/opencode-actions/review@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          model: deepseek/deepseek-v4-flash
 
           # only one is enough.
           zhipu-api-key: ${{ secrets.ZHIPU_API_KEY }}


### PR DESCRIPTION
## Why

`zhipuai-coding-plan/glm-5.1` (current default of the `review` action) is too slow for routine PR review.

## Change

Add `model: deepseek/deepseek-v4-flash` to the `review` action invocation in `.github/workflows/CI.yml`. Single line, no other changes.