### PR TITLE
fix(frontend): disable publish button when article is already published

### DIFF
--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -312,6 +312,10 @@ export default function Editor() {
       showNotification('未选择文件', 'error');
       return;
     }
+    if (isPublished) {
+      showNotification('文章已发布', 'info');
+      return;
+    }
     if (!confirm('确定要发布这篇文章吗？发布后将无法撤销草稿状态。')) return;
     setPublishing(true);
     try {
@@ -501,7 +505,7 @@ export default function Editor() {
               <Save className="w-5 h-5 mr-2" />
               {saving ? '保存中...' : hasChanges ? '保存 (Ctrl+S)' : '已保存'}
             </button>
-            <button onClick={publishArticle} disabled={publishing || !currentFile} className={`px-4 py-2 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center ${isPublished ? 'bg-stone-400 hover:bg-stone-500' : 'bg-green-600 hover:bg-green-700'}`}>
+            <button onClick={publishArticle} disabled={publishing || !currentFile || isPublished} className={`px-4 py-2 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center ${isPublished ? 'bg-stone-400 hover:bg-stone-500' : 'bg-green-600 hover:bg-green-700'}`}>
               <Upload className="w-5 h-5 mr-2" />
               {publishing ? '发布中...' : isPublished ? '已发布' : '发布'}
             </button>


### PR DESCRIPTION
## Problem

Clicking '发布' on an article that was already published calls `/api/article/publish` again. The backend correctly returns HTTP 409 with message '已经发布' (already published), and the frontend then shows '发布失败: ...' — confusing, since the article is in the desired state.

## Fix

Two small changes in `frontend/src/pages/Editor.tsx`:

1. `publishArticle()` early-returns if `isPublished` is already true (with an 'info' notification).
2. The publish button's `disabled` prop now also includes `isPublished`, so it cannot be clicked in that state.

The button label ternary (`isPublished ? '已发布' : '发布'`) was already correct, so the combined effect is a coherent 'already published' state — the user sees '已发布' on a greyed-out button they cannot click.

## Verification

Rebuilt `static/dist/` (gitignored) and confirmed via `grep` that the new guard `if(_){Ee('文章已发布'...)` made it into the minified JS. Same control flow for the disabled-button change. The dist artifact on the running server is already updated to this build.

## Scope

Pure UI guard. No backend change. (Unpublish is intentionally out of scope.)