### PR TITLE
fix(editor): give textarea a white background to match the preview pane

### DIFF
--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -594,7 +594,7 @@ export default function Editor() {
               onChange={(e) => setContent(e.target.value)}
               onPaste={handlePaste}
               placeholder="在此输入 Markdown 内容..."
-              className="flex-1 w-full font-mono text-sm p-4 border border-stone-200 rounded-lg resize-none focus:ring-2 focus:ring-stone-400 focus:border-transparent outline-none"
+              className="flex-1 w-full font-mono text-sm p-4 border border-stone-200 rounded-lg bg-white resize-none focus:ring-2 focus:ring-stone-400 focus:border-transparent outline-none"
               style={{ lineHeight: 1.6 }}
             />
           </div>


### PR DESCRIPTION
## Problem

Editor page's two-column layout (editor / preview) was visually asymmetric. The preview pane had an explicit `bg-white`, but the editor `<textarea>` did not. With no background, the textarea showed through to the main container's `bg-stone-50` (warm gray-cream), so as soon as the preview content extended past the editor content, the user saw a 'gray' surface inside the editor's bordered box.

## Fix

Add `bg-white` to the textarea's className. Single class addition, no other changes — the textarea already has its own native scrolling behaviour, so no `overflow-y-auto` was added.

## Verification

- `pnpm run build` clean.
- `tsc -b` (run by build script) clean.
- Visual check via agent-browser: after a hard refresh, the editor and preview panes now share the same white surface tone.