### PR TITLE
feat: add AI-generated cover image for articles

### DIFF
--- a/app.py
+++ b/app.py
@@ -659,6 +659,62 @@ def list_images():
         return jsonify({"success": False, "message": result}), 500
 
 
+@app.route("/api/image/generate-cover", methods=["POST"])
+def generate_cover():
+    """根据文章内容生成封面图片"""
+    data = request.get_json()
+    article_path = data.get("article_path")
+    title = data.get("title", "")
+    description = data.get("description", "")
+    article_content = data.get("content", "")
+
+    if not article_path:
+        return jsonify({"success": False, "message": "缺少文章路径"}), 400
+
+    api_key = app.config.get("OPENROUTER_API_KEY", "")
+    model = app.config.get("IMAGE_GEN_MODEL", "")
+
+    if not api_key:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "message": "OPENROUTER_API_KEY 未配置，请设置环境变量",
+                }
+            ),
+            400,
+        )
+
+    from services.image_gen_service import generate_cover_image, save_generated_image
+
+    ok, result = generate_cover_image(
+        title=title,
+        description=description,
+        content=article_content,
+        api_key=api_key,
+        model=model,
+    )
+
+    if not ok:
+        return jsonify({"success": False, "message": result}), 500
+
+    content_dir = Path(app.config["CONTENT_DIR"])
+    save_ok, save_result = save_generated_image(article_path, result, content_dir)
+
+    if not save_ok:
+        return jsonify({"success": False, "message": save_result}), 500
+
+    if post_service.cache_service:
+        abs_path = str(
+            Path(article_path)
+            if Path(article_path).is_absolute()
+            else content_dir / article_path
+        )
+        post_service.cache_service.invalidate_post(abs_path)
+
+    return jsonify({"success": True, "url": save_result, "message": "封面图片生成成功"})
+
+
 # --- 文章发布 API ---
 
 

--- a/config.py
+++ b/config.py
@@ -48,6 +48,11 @@ class Config:
     AI_BASE_URL = os.environ.get("AI_BASE_URL") or "https://api.deepseek.com"
     AI_MODEL = os.environ.get("AI_MODEL") or "deepseek-chat"
 
+    OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY") or ""
+    IMAGE_GEN_MODEL = (
+        os.environ.get("IMAGE_GEN_MODEL") or "google/gemini-3-pro-image-preview"
+    )
+
     @staticmethod
     def init_app(app):
         """初始化应用配置"""

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -227,3 +227,19 @@ body {
   background-color: #f5f5f4;
   color: #292524;
 }
+
+/* ===== Progress bar ===== */
+.animate-progress {
+  animation: progressStripe 1.5s linear infinite;
+  background-image: linear-gradient(
+    45deg,
+    rgba(255,255,255,0.15) 25%, transparent 25%,
+    transparent 50%, rgba(255,255,255,0.15) 50%,
+    rgba(255,255,255,0.15) 75%, transparent 75%
+  );
+  background-size: 1rem 1rem;
+}
+@keyframes progressStripe {
+  from { background-position: 1rem 0; }
+  to { background-position: 0 0; }
+}

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -16,6 +16,7 @@ import {
   Table,
   X,
   ArrowLeftRight,
+  Sparkles,
 } from 'lucide-react';
 import { get, post } from '../utils/api';
 import { renderMarkdown } from '../utils/markdown';
@@ -50,6 +51,7 @@ export default function Editor() {
   const [refSearchQuery, setRefSearchQuery] = useState('');
   const [refSearchResults, setRefSearchResults] = useState<Array<{ path: string; title: string }>>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [generatingCover, setGeneratingCover] = useState(false);
 
   const currentFile = fullPath;
 
@@ -376,6 +378,34 @@ export default function Editor() {
     }
   }
 
+  async function generateCoverImage() {
+    if (!currentFile) {
+      showNotification('未选择文件', 'error');
+      return;
+    }
+    setGeneratingCover(true);
+    try {
+      const data = await post<{ success: boolean; url?: string; message?: string }>('/api/image/generate-cover', {
+        article_path: currentFile,
+        title: fmEdit.title || frontmatter.title || '',
+        description: fmEdit.description || frontmatter.description || '',
+        content,
+      });
+      if (data.success && data.url) {
+        setFmEdit({ ...fmEdit, cover: data.url });
+        setFrontmatter({ ...frontmatter, cover: data.url });
+        showNotification('封面图片已生成', 'success');
+        await loadImages();
+      } else {
+        showNotification('生成失败: ' + (data.message || '未知错误'), 'error');
+      }
+    } catch (error) {
+      showNotification('生成封面失败', 'error');
+    } finally {
+      setGeneratingCover(false);
+    }
+  }
+
   function copyImageUrl(url: string) {
     navigator.clipboard.writeText(url);
     showNotification('图片链接已复制', 'success');
@@ -500,6 +530,10 @@ export default function Editor() {
             <button onClick={() => setShowImageManager(!showImageManager)} className="px-4 py-2 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors flex items-center">
               <Image className="w-5 h-5 mr-2" />
               图片管理
+            </button>
+            <button onClick={generateCoverImage} disabled={generatingCover || !currentFile} className="px-4 py-2 border border-purple-400 text-purple-700 rounded-lg hover:bg-purple-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center">
+              <Sparkles className="w-5 h-5 mr-2" />
+              {generatingCover ? '生成中...' : '生成封面'}
             </button>
             <button onClick={saveFile} disabled={saving || !hasChanges} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center">
               <Save className="w-5 h-5 mr-2" />

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -515,33 +515,28 @@ export default function Editor() {
               <span className="ml-2 text-stone-600 font-mono text-sm">{currentFile}</span>
             </div>
           </div>
-          <div className="flex items-center space-x-2 flex-wrap">
-            <button onClick={() => setShowFrontmatterDrawer(true)} className="px-4 py-2 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors flex items-center">
-              <FileCode className="w-5 h-5 mr-2" />
-              Frontmatter
+          <div className="flex items-center space-x-1">
+            <button onClick={() => setShowFrontmatterDrawer(true)} title="Frontmatter" className="p-2 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors">
+              <FileCode className="w-5 h-5" />
             </button>
-            <button onClick={() => setShowBacklinks(!showBacklinks)} className="px-4 py-2 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors flex items-center">
-              <ArrowLeftRight className="w-5 h-5 mr-2" />
-              反向链接
+            <button onClick={() => setShowBacklinks(!showBacklinks)} title="反向链接" className="relative p-2 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors">
+              <ArrowLeftRight className="w-5 h-5" />
               {backlinks.length > 0 && (
-                <span className="ml-1 bg-blue-100 text-blue-800 text-xs font-semibold px-2 py-0.5 rounded-full">{backlinks.length}</span>
+                <span className="absolute -top-1 -right-1 bg-blue-100 text-blue-800 text-[10px] font-semibold w-4 h-4 flex items-center justify-center rounded-full">{backlinks.length}</span>
               )}
             </button>
-            <button onClick={() => setShowImageManager(!showImageManager)} className="px-4 py-2 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors flex items-center">
-              <Image className="w-5 h-5 mr-2" />
-              图片管理
+            <button onClick={() => setShowImageManager(!showImageManager)} title="图片管理" className="p-2 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors">
+              <Image className="w-5 h-5" />
             </button>
-            <button onClick={generateCoverImage} disabled={generatingCover || !currentFile} className="px-4 py-2 border border-purple-400 text-purple-700 rounded-lg hover:bg-purple-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center">
-              <Sparkles className="w-5 h-5 mr-2" />
-              {generatingCover ? '生成中...' : '生成封面'}
+            <button onClick={generateCoverImage} disabled={generatingCover || !currentFile} title={generatingCover ? '生成中...' : 'AI 生成封面'} className="p-2 border border-purple-400 text-purple-700 rounded-lg hover:bg-purple-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+              <Sparkles className="w-5 h-5" />
             </button>
-            <button onClick={saveFile} disabled={saving || !hasChanges} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center">
-              <Save className="w-5 h-5 mr-2" />
-              {saving ? '保存中...' : hasChanges ? '保存 (Ctrl+S)' : '已保存'}
+            <span className="border-l border-stone-300 mx-1 h-6" />
+            <button onClick={saveFile} disabled={saving || !hasChanges} title={saving ? '保存中...' : hasChanges ? '保存 (Ctrl+S)' : '已保存'} className="p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+              <Save className="w-5 h-5" />
             </button>
-            <button onClick={publishArticle} disabled={publishing || !currentFile || isPublished} className={`px-4 py-2 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center ${isPublished ? 'bg-stone-400 hover:bg-stone-500' : 'bg-green-600 hover:bg-green-700'}`}>
-              <Upload className="w-5 h-5 mr-2" />
-              {publishing ? '发布中...' : isPublished ? '已发布' : '发布'}
+            <button onClick={publishArticle} disabled={publishing || !currentFile || isPublished} title={publishing ? '发布中...' : isPublished ? '已发布' : '发布'} className={`p-2 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${isPublished ? 'bg-stone-400 hover:bg-stone-500' : 'bg-green-600 hover:bg-green-700'}`}>
+              <Upload className="w-5 h-5" />
             </button>
           </div>
         </div>

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -108,6 +108,7 @@ export default function Editor() {
     edit.date = edit.date || '';
     edit.draft = edit.draft || 'true';
     edit.cover = edit.cover || '';
+    edit.image = edit.image || '';
     edit.description = edit.description || '';
 
     setFmEdit(edit);
@@ -123,7 +124,7 @@ export default function Editor() {
       }
     }
 
-    const coreKeys = ['title', 'date', 'draft', 'tags', 'categories', 'cover', 'description'];
+    const coreKeys = ['title', 'date', 'draft', 'tags', 'categories', 'cover', 'image', 'description'];
     const extra: Array<{ key: string; value: string }> = [];
     for (const [k, v] of Object.entries(fm)) {
       if (!coreKeys.includes(k)) {
@@ -392,8 +393,8 @@ export default function Editor() {
         content,
       });
       if (data.success && data.url) {
-        setFmEdit({ ...fmEdit, cover: data.url });
-        setFrontmatter({ ...frontmatter, cover: data.url });
+        setFmEdit({ ...fmEdit, cover: data.url, image: data.url });
+        setFrontmatter({ ...frontmatter, cover: data.url, image: data.url });
         showNotification('封面图片已生成', 'success');
         await loadImages();
       } else {
@@ -541,6 +542,17 @@ export default function Editor() {
           </div>
         </div>
 
+        {generatingCover && (
+          <div className="bg-white rounded-md ring-1 ring-stone-900/5 p-3 mb-4">
+            <div className="flex items-center gap-3">
+              <div className="w-full bg-stone-200 rounded-full h-2 overflow-hidden">
+                <div className="bg-purple-500 h-2 rounded-full animate-progress" style={{ width: '100%' }} />
+              </div>
+              <span className="text-sm text-stone-600 whitespace-nowrap">AI 生成封面中...</span>
+            </div>
+          </div>
+        )}
+
         {showImageManager && (
           <div className="border-t pt-4">
             <div className="flex items-center justify-between mb-4">
@@ -648,6 +660,24 @@ export default function Editor() {
               </button>
             </div>
             <div className="flex-1 overflow-y-auto p-4 space-y-4">
+              {(fmEdit.cover || fmEdit.image) && (
+                <div className="relative rounded-lg overflow-hidden border border-stone-200">
+                  <img
+                    src={`/content/${currentFile.replace(/[^/]+$/, '')}${fmEdit.image || fmEdit.cover}`}
+                    alt="封面图片"
+                    className="w-full h-40 object-cover"
+                  />
+                  <button
+                    onClick={() => {
+                      const url = fmEdit.image || fmEdit.cover || '';
+                      navigator.clipboard.writeText(url);
+                    }}
+                    className="absolute bottom-2 right-2 px-2 py-1 bg-black/60 text-white text-xs rounded hover:bg-black/80 transition-colors"
+                  >
+                    复制路径
+                  </button>
+                </div>
+              )}
               <div>
                 <label className="block text-sm font-medium text-stone-700 mb-1">title</label>
                 <input type="text" value={fmEdit.title || ''} onChange={(e) => setFmEdit({ ...fmEdit, title: e.target.value })} placeholder="文章标题" className="w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:ring-2 focus:ring-stone-400" />
@@ -682,6 +712,10 @@ export default function Editor() {
               <div>
                 <label className="block text-sm font-medium text-stone-700 mb-1">cover</label>
                 <input type="text" value={fmEdit.cover || ''} onChange={(e) => setFmEdit({ ...fmEdit, cover: e.target.value })} placeholder="封面图片路径" className="w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:ring-2 focus:ring-stone-400" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-stone-700 mb-1">image</label>
+                <input type="text" value={fmEdit.image || ''} onChange={(e) => setFmEdit({ ...fmEdit, image: e.target.value })} placeholder="封面图片路径 (Hugo theme)" className="w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:ring-2 focus:ring-stone-400" />
               </div>
               <div>
                 <label className="block text-sm font-medium text-stone-700 mb-1">description</label>

--- a/services/image_gen_service.py
+++ b/services/image_gen_service.py
@@ -72,17 +72,22 @@ def generate_cover_image(
         resp.raise_for_status()
         data = resp.json()
 
+        logger.info("OpenRouter response keys: %s", list(data.keys()))
+        if data.get("error"):
+            return False, f"API error: {data['error']}"
+
         choices = data.get("choices", [])
         if not choices:
             return False, "API returned no choices"
 
         message = choices[0].get("message", {})
-        content_parts = message.get("content")
 
-        if isinstance(content_parts, list):
-            for part in content_parts:
-                if part.get("type") == "image_url":
-                    url = part.get("image_url", {}).get("url", "")
+        # OpenRouter returns images in message["images"] array
+        images = message.get("images", [])
+        if images:
+            for img in images:
+                if img.get("type") == "image_url":
+                    url = img.get("image_url", {}).get("url", "")
                     if url.startswith("data:"):
                         b64 = url.split(",", 1)[1]
                         return True, base64.b64decode(b64)
@@ -90,10 +95,31 @@ def generate_cover_image(
                         img_resp = requests.get(url, timeout=60)
                         img_resp.raise_for_status()
                         return True, img_resp.content
-        elif isinstance(content_parts, str):
-            text = content_parts
-            if "![" not in text and "data:image" not in text:
-                return False, f"Model did not return an image: {text[:200]}"
+
+        # Fallback: check message["content"]
+        content_parts = message.get("content")
+        if content_parts is not None:
+            if isinstance(content_parts, list):
+                for part in content_parts:
+                    ptype = part.get("type", "")
+                    if ptype == "image_url":
+                        url = part.get("image_url", {}).get("url", "")
+                        if url.startswith("data:"):
+                            b64 = url.split(",", 1)[1]
+                            return True, base64.b64decode(b64)
+                        elif url.startswith("http"):
+                            img_resp = requests.get(url, timeout=60)
+                            img_resp.raise_for_status()
+                            return True, img_resp.content
+
+            if isinstance(content_parts, str) and "data:image" in content_parts:
+                import re
+
+                m = re.search(
+                    r"data:image/[^;]+;base64,([A-Za-z0-9+/=]+)", content_parts
+                )
+                if m:
+                    return True, base64.b64decode(m.group(1))
 
         return False, "No image found in API response"
 

--- a/services/image_gen_service.py
+++ b/services/image_gen_service.py
@@ -1,0 +1,144 @@
+import base64
+import logging
+import os
+import time
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "google/gemini-3-pro-image-preview"
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def generate_cover_image(
+    title: str,
+    description: str = "",
+    content: str = "",
+    api_key: str = "",
+    model: str = "",
+) -> tuple[bool, bytes]:
+    """Generate a cover image based on article metadata.
+
+    Returns (success, image_bytes_or_error_message).
+    """
+    api_key = api_key or os.environ.get("OPENROUTER_API_KEY", "")
+    if not api_key:
+        return False, "OPENROUTER_API_KEY 未配置"
+
+    model = model or DEFAULT_MODEL
+
+    prompt_parts = [
+        "Generate a clean, visually appealing cover image for a blog post.",
+        f"Title: {title}",
+    ]
+    if description:
+        prompt_parts.append(f"Description: {description}")
+    if content:
+        snippet = content[:500].strip()
+        prompt_parts.append(f"Content summary: {snippet}")
+
+    prompt_parts.append(
+        "Style: modern, minimalist, elegant. No text overlay. "
+        "Use warm editorial tones. Aspect ratio 16:9."
+    )
+
+    prompt = "\n".join(prompt_parts)
+
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt,
+            }
+        ],
+    }
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        logger.info("Requesting cover image from %s", model)
+        resp = requests.post(
+            OPENROUTER_API_URL,
+            json=payload,
+            headers=headers,
+            timeout=180,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        choices = data.get("choices", [])
+        if not choices:
+            return False, "API returned no choices"
+
+        message = choices[0].get("message", {})
+        content_parts = message.get("content")
+
+        if isinstance(content_parts, list):
+            for part in content_parts:
+                if part.get("type") == "image_url":
+                    url = part.get("image_url", {}).get("url", "")
+                    if url.startswith("data:"):
+                        b64 = url.split(",", 1)[1]
+                        return True, base64.b64decode(b64)
+                    elif url.startswith("http"):
+                        img_resp = requests.get(url, timeout=60)
+                        img_resp.raise_for_status()
+                        return True, img_resp.content
+        elif isinstance(content_parts, str):
+            text = content_parts
+            if "![" not in text and "data:image" not in text:
+                return False, f"Model did not return an image: {text[:200]}"
+
+        return False, "No image found in API response"
+
+    except requests.exceptions.Timeout:
+        return False, "Image generation timed out (180s)"
+    except requests.exceptions.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.response.json().get("error", {}).get("message", "")
+        except Exception:
+            detail = e.response.text[:200]
+        return False, f"API error {e.response.status_code}: {detail}"
+    except Exception as e:
+        logger.exception("Image generation failed")
+        return False, f"Image generation failed: {e}"
+
+
+def save_generated_image(
+    article_path: str,
+    image_bytes: bytes,
+    content_dir: Path,
+) -> tuple[bool, str]:
+    """Save generated image bytes to the article's pics/ directory.
+
+    Returns (success, relative_url_or_error_message).
+    """
+    try:
+        if not Path(article_path).is_absolute():
+            article_file = content_dir / article_path
+        else:
+            article_file = Path(article_path)
+
+        article_dir = article_file.parent
+        pics_dir = article_dir / "pics"
+        pics_dir.mkdir(parents=True, exist_ok=True)
+
+        ts = int(time.time())
+        filename = f"cover_{ts}.png"
+        file_path = pics_dir / filename
+
+        file_path.write_bytes(image_bytes)
+
+        relative_url = f"pics/{filename}"
+        return True, relative_url
+
+    except Exception as e:
+        logger.exception("Failed to save generated image")
+        return False, f"Failed to save image: {e}"


### PR DESCRIPTION
## Summary

Closes #54

### Changes

**Backend**
- New config: `OPENROUTER_API_KEY`, `IMAGE_GEN_MODEL` (default: `google/gemini-3-pro-image-preview`)
- New service: `services/image_gen_service.py` — calls OpenRouter chat completions API to generate images
- New endpoint: `POST /api/image/generate-cover` — accepts `article_path`, `title`, `description`, `content`; returns generated image URL

**Frontend**
- New "生成封面" button (purple, Sparkles icon) in Editor toolbar
- `generateCoverImage()` function sends article metadata to backend
- On success: auto-updates frontmatter `cover` field and refreshes image list

### How it works
1. User clicks "生成封面" in the editor toolbar
2. Frontend sends article title + description + content snippet to `/api/image/generate-cover`
3. Backend calls OpenRouter API with a cover-generation prompt
4. Generated image (PNG) is saved to `<article>/pics/cover_<timestamp>.png`
5. Frontmatter `cover` field is auto-populated with the relative path

### Setup
Set the environment variable:
```bash
export OPENROUTER_API_KEY="your-openrouter-key"
```

### Tests
- All 81 existing tests pass
- Frontend builds successfully