### PR TITLE
fix(editor): resolve stale closure in Ctrl+S keyboard handler

### DIFF
--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import {
   Save,
@@ -31,7 +31,10 @@ export default function Editor() {
   const [content, setContent] = useState('');
   const [originalContent, setOriginalContent] = useState('');
   const [preview, setPreview] = useState('');
-  const [hasChanges, setHasChanges] = useState(false);
+  const hasChanges = useMemo(
+    () => content !== originalContent || JSON.stringify(frontmatter) !== JSON.stringify(originalFrontmatter),
+    [content, originalContent, frontmatter, originalFrontmatter],
+  );
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -52,6 +55,10 @@ export default function Editor() {
   const [refSearchQuery, setRefSearchQuery] = useState('');
   const [refSearchResults, setRefSearchResults] = useState<Array<{ path: string; title: string }>>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const saveFileRef = useRef(saveFile);
+  saveFileRef.current = saveFile;
+  const insertMarkdownRef = useRef(insertMarkdown);
+  insertMarkdownRef.current = insertMarkdown;
   const [generatingCover, setGeneratingCover] = useState(false);
   const [generatingFm, setGeneratingFm] = useState(false);
 
@@ -69,11 +76,6 @@ export default function Editor() {
     updatePreview();
   }, [content, currentFile]);
 
-  useEffect(() => {
-    setHasChanges(
-      content !== originalContent || JSON.stringify(frontmatter) !== JSON.stringify(originalFrontmatter),
-    );
-  }, [content, originalContent, frontmatter, originalFrontmatter]);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -83,15 +85,15 @@ export default function Editor() {
       }
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
-        if (hasChanges && !saving) saveFile();
+        if (hasChanges && !saving) saveFileRef.current();
       }
       if ((e.ctrlKey || e.metaKey) && e.key === 'b') {
         e.preventDefault();
-        insertMarkdown('bold');
+        insertMarkdownRef.current('bold');
       }
       if ((e.ctrlKey || e.metaKey) && e.key === 'i') {
         e.preventDefault();
-        insertMarkdown('italic');
+        insertMarkdownRef.current('italic');
       }
     }
     document.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
## Repro
1. Open an article in the Editor
2. Edit content (hasChanges becomes true, effect re-registers with current saveFile)
3. Continue editing more content (hasChanges stays true, effect does NOT re-register)
4. Press Ctrl+S → saves content from step 2, NOT the latest edits

## Cause
`Editor.tsx` keyboard `useEffect` (line 80) registered a `keydown` handler with deps `[hasChanges, saving, showRefModal]`. The handler called `saveFile()` and `insertMarkdown()` closures captured at registration time. When `hasChanges` was already `true`, subsequent content edits did not trigger re-registration, so the handler held stale function closures referencing old content.

Additionally, `hasChanges` was derived via a separate `useEffect + useState`, introducing an unnecessary render cycle that contributed to stale timing.

## Fix
- Convert `hasChanges` from `useEffect`-derived state to `useMemo` (synchronous, no extra render)
- Add `saveFileRef` and `insertMarkdownRef`, updated on every render
- Rewire keyboard handler to call via refs: `saveFileRef.current()` and `insertMarkdownRef.current()`
- Refs bypass the closure problem entirely — the handler always invokes the latest function

## Verification
- `cd frontend && bun x tsc --noEmit`: no type errors
- Verified diff: 1 file, +12/-10 lines, targeted only the affected code paths
- Save button (onClick) was unaffected by this bug and continues to work correctly

Fixes #67