### PR TITLE
fix(editor): use functional setState in handlePaste to fix stale closure

### DIFF
--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -493,6 +493,7 @@ export default function Editor() {
         e.preventDefault();
         const blob = items[i].getAsFile();
         if (blob && currentFile) {
+          const cursorPos = textareaRef.current?.selectionStart ?? -1;
           const formData = new FormData();
           formData.append('file', blob);
           formData.append('article_path', currentFile);
@@ -501,13 +502,11 @@ export default function Editor() {
             .then((data) => {
               if (data.success) {
                 const url = data.url || data.image_url;
-                const textarea = textareaRef.current;
-                if (textarea) {
-                  const start = textarea.selectionStart;
-                  const insertion = `![图片](${url})`;
-                  const newContent = content.substring(0, start) + insertion + content.substring(start);
-                  setContent(newContent);
-                }
+                const insertion = `![图片](${url})`;
+                setContent((prev) => {
+                  const pos = cursorPos >= 0 ? cursorPos : prev.length;
+                  return prev.substring(0, pos) + insertion + prev.substring(pos);
+                });
                 loadImages();
               }
             })


### PR DESCRIPTION
## Repro

1. Open an article in the editor
2. Type some text
3. Paste an image (triggers async upload via `/api/image/upload`)
4. Before the upload completes, continue typing more text
5. When the upload completes, the `.then()` callback calls `setContent` with the stale `content` captured at paste time — overwriting all edits from step 4

## Cause

`handlePaste` in `frontend/src/pages/Editor.tsx:508` captures `content` in a closure inside the async `fetch().then()` chain:

```ts
.then((data) => {
  const newContent = content.substring(0, start) + insertion + content.substring(start);
  setContent(newContent);
});
```

Since `content` is captured at the time `handlePaste` executes (before the upload), any edits the user makes during the upload window are lost when `setContent(newContent)` fires.

Additionally, reading `textarea.selectionStart` inside the async callback is unsafe — the cursor may have moved.

## Fix

- Capture the cursor position (`cursorPos`) before the async `fetch` call
- Use functional `setContent(prev => ...)` so the callback always operates on the latest state, never on a stale closure value
- Use the captured `cursorPos` instead of reading `textarea.selectionStart` in the async callback

## Verification

No frontend test framework configured in this repo. Verified by inspection:
- `cursorPos` is read synchronously before any `await`/`.then()` boundary
- `setContent` uses the functional updater form, guaranteeing `prev` is the latest rendered state
- TypeScript type compatibility unchanged (same `useState<string>`, same substring operations)

`Fixes #76`