### PR TITLE
fix(post_service): stop blank-line accumulation between frontmatter and body

### DIFF
--- a/services/post_service.py
+++ b/services/post_service.py
@@ -593,6 +593,8 @@ class PostService:
         """
         反复剥除 content 开头连续的 '---' 块, 直到正文不再以 '---' 起头.
         防止 save 时与 frontmatter_data 拼接产生双重 frontmatter.
+        同时剥除正文开头的空行, 与 frontmatter.dumps 的模板保持对称,
+        避免空行逐次累积.
         """
         if not isinstance(content, str) or not content:
             return content
@@ -614,6 +616,9 @@ class PostService:
                     break
             if not closed:
                 return content
+        # 剥除正文开头的空行, 与 frontmatter.dumps 模板对齐
+        if content:
+            content = content.lstrip("\n")
         return content
 
     def _safe_file_operation(self, file_path, operation, timeout=10):

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -618,7 +618,7 @@ class PostService:
                 return content
         # 剥除正文开头的空行, 与 frontmatter.dumps 模板对齐
         if content:
-            content = content.lstrip("\n")
+            content = content.lstrip("\r\n")
         return content
 
     def _safe_file_operation(self, file_path, operation, timeout=10):

--- a/tests/test_post_service_publish.py
+++ b/tests/test_post_service_publish.py
@@ -126,7 +126,9 @@ Content 2
         assert post1.get("draft") is False
         assert post2.get("draft") is False
 
-    def test_no_blank_line_accumulation_on_save_cycle(self, post_service, temp_content_dir):
+    def test_no_blank_line_accumulation_on_save_cycle(
+        self, post_service, temp_content_dir
+    ):
         """多次保存不应累积 frontmatter 与正文之间的空行"""
         file_path = temp_content_dir / "no-accum.md"
 
@@ -150,9 +152,9 @@ Content 2
         # 关键断言：5 次保存后空行数目 ≤ 1（不会累积增长）
         body_section = parts[2]
         leading_newlines = len(body_section) - len(body_section.lstrip("\n"))
-        assert leading_newlines <= 1, (
-            f"Expected ≤1 leading newlines after 5 saves, got {leading_newlines}"
-        )
+        assert (
+            leading_newlines <= 1
+        ), f"Expected ≤1 leading newlines after 5 saves, got {leading_newlines}"
 
 
 class TestStripLeadingFrontmatter:
@@ -171,6 +173,9 @@ class TestStripLeadingFrontmatter:
         # 多个开头空行
         assert svc._strip_leading_frontmatter("\n\n\nhello world") == "hello world"
 
+        # Windows 换行符 (\r\n)
+        assert svc._strip_leading_frontmatter("\r\n\r\nhello world") == "hello world"
+
         # 仅空行
         assert svc._strip_leading_frontmatter("\n\n") == ""
 
@@ -179,4 +184,3 @@ class TestStripLeadingFrontmatter:
 
         # None
         assert svc._strip_leading_frontmatter(None) is None
-

--- a/tests/test_post_service_publish.py
+++ b/tests/test_post_service_publish.py
@@ -125,3 +125,58 @@ Content 2
         post2 = frontmatter.load(str(article2))
         assert post1.get("draft") is False
         assert post2.get("draft") is False
+
+    def test_no_blank_line_accumulation_on_save_cycle(self, post_service, temp_content_dir):
+        """多次保存不应累积 frontmatter 与正文之间的空行"""
+        file_path = temp_content_dir / "no-accum.md"
+
+        # 初始文件：frontmatter 后无空行
+        initial = "---\ntitle: Test\n---\nhello world"
+        file_path.write_text(initial)
+
+        for _ in range(5):
+            success, body, fm = post_service.read_file_with_frontmatter(str(file_path))
+            assert success
+            success, msg = post_service.save_file(
+                str(file_path), body, frontmatter_data=fm
+            )
+            assert success
+
+        # 检查最终文件：--- 结束标记与正文之间应只有 1 个空行（dumps 模板固定插入）
+        content = file_path.read_text()
+        parts = content.split("---\n", 2)
+        assert len(parts) >= 3
+        # dumps 模板固定插入 \n\n，所以正文前始终有 1 个空行
+        # 关键断言：5 次保存后空行数目 ≤ 1（不会累积增长）
+        body_section = parts[2]
+        leading_newlines = len(body_section) - len(body_section.lstrip("\n"))
+        assert leading_newlines <= 1, (
+            f"Expected ≤1 leading newlines after 5 saves, got {leading_newlines}"
+        )
+
+
+class TestStripLeadingFrontmatter:
+    """_strip_leading_frontmatter 回归测试"""
+
+    def test_strips_leading_blank_lines(self):
+        """正文开头空行应被剥除，避免与 frontmatter.dumps 不对称累积"""
+        svc = PostService.__new__(PostService)
+
+        # 无开头空行 — 保持不变
+        assert svc._strip_leading_frontmatter("hello world") == "hello world"
+
+        # 单个开头空行
+        assert svc._strip_leading_frontmatter("\nhello world") == "hello world"
+
+        # 多个开头空行
+        assert svc._strip_leading_frontmatter("\n\n\nhello world") == "hello world"
+
+        # 仅空行
+        assert svc._strip_leading_frontmatter("\n\n") == ""
+
+        # 空字符串
+        assert svc._strip_leading_frontmatter("") == ""
+
+        # None
+        assert svc._strip_leading_frontmatter(None) is None
+

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "hugo-admin"
-version = "1.4.1"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Repro
Create a markdown file `---\ntitle: test\n---\nhello world`, then read with `read_file_with_frontmatter` and save with `save_file` repeatedly. Each cycle adds one blank line between the `---` closing delimiter and the body content. After 5 saves, there are 5 blank lines.

## Cause
`frontmatter.dumps(post)` uses the template `'{start_delimiter}\n{metadata}\n{end_delimiter}\n\n{content}\n'` which always inserts `\n\n` before the body. `_strip_leading_frontmatter` only strips leading blank lines **inside** the `---`-block stripping loop (lines 609-611) but never from the final result (line 617: bare `return content`). A body that doesn't start with `---` — e.g. starts with `\n` from a prior save — passes through unchanged, gets another `\n\n` prepended by `dumps`, and the cycle compounds.

## Fix
- `services/post_service.py`: `_strip_leading_frontmatter` now also strips leading `\n` characters from the final result after the `---`-stripping loop, making it symmetric with `frontmatter.dumps`'s template.
- `tests/test_post_service_publish.py`: Added `TestStripLeadingFrontmatter` unit tests for the method's edge cases, and `TestPostServicePublish::test_no_blank_line_accumulation_on_save_cycle` integration test that verifies 5 save cycles produce ≤1 leading blank line.

## Verification
`python3 -m pytest tests/ -v --ignore=tests/test_ai_service.py --ignore=tests/test_publish_api.py --ignore=tests/test_publish_integration.py --ignore=tests/test_settings_api.py --ignore=tests/test_spa_routes.py` — 63 passed (4 pre-existing failures from missing `anyio` dependency, unrelated).

Fixes #79