### PR TITLE
fix(email): replace fragile endswith URL matching with normalized URL comparison

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -6,19 +6,17 @@
 """
 
 import json
-from urllib.parse import urlparse
 import re
 import smtplib
 from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
+from urllib.parse import urlparse
 
 import feedparser
 import requests
 import yaml
-
-
 
 
 def _strip_html_suffix(path):
@@ -32,6 +30,8 @@ def _strip_html_suffix(path):
     if path.endswith(".htm"):
         return path[: -len(".htm")]
     return path
+
+
 class EmailService:
     """邮件推送服务"""
 
@@ -180,7 +180,9 @@ class EmailService:
 
                 # path-only 输入：忽略 netloc，仅比对 path
                 # 完整 URL 输入：netloc 与 path 都需匹配
-                netloc_matches = (target_netloc == "") or (target_netloc == entry_netloc)
+                netloc_matches = (target_netloc == "") or (
+                    target_netloc == entry_netloc
+                )
                 if netloc_matches and target_path == entry_path:
                     matches.append(entry)
 

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -6,6 +6,7 @@
 """
 
 import json
+from urllib.parse import urlparse
 import re
 import smtplib
 from datetime import datetime
@@ -18,6 +19,19 @@ import requests
 import yaml
 
 
+
+
+def _strip_html_suffix(path):
+    """Remove trailing index.html, index.htm, .html, .htm from a URL path."""
+    if path.endswith("/index.html"):
+        return path[: -len("/index.html")]
+    if path.endswith("/index.htm"):
+        return path[: -len("/index.htm")]
+    if path.endswith(".html"):
+        return path[: -len(".html")]
+    if path.endswith(".htm"):
+        return path[: -len(".htm")]
+    return path
 class EmailService:
     """邮件推送服务"""
 
@@ -99,6 +113,41 @@ class EmailService:
         except Exception as e:
             raise Exception(f"获取 RSS 失败: {e}")
 
+    @staticmethod
+    def _normalize_url_for_match(raw_url):
+        """
+        归一化用户输入的 URL 或路径，用于与 RSS 条目比对。
+
+        返回 (netloc, path) 元组。path 已去尾斜杠、去 index.html/.html 后缀。
+        netloc 为小写、去除 www. 前缀。netloc 为空字符串表示用户输入的是路径。
+        裸 slug（无 / 无 .）返回 None。
+        """
+        if not raw_url or not raw_url.strip():
+            return None
+
+        url = raw_url.strip()
+
+        # 裸 slug（无斜杠、无点号）→ 拒绝
+        if "/" not in url and "." not in url:
+            return None
+
+        # path-only（以 / 开头）
+        if url.startswith("/"):
+            path = url.rstrip("/")
+            return ("", _strip_html_suffix(path))
+
+        # 无 scheme 的非路径输入：补 https://
+        if "://" not in url:
+            url = "https://" + url
+
+        parsed = urlparse(url)
+        netloc = parsed.netloc.lower()
+        if netloc.startswith("www."):
+            netloc = netloc[4:]
+
+        path = parsed.path.rstrip("/")
+        return (netloc, _strip_html_suffix(path))
+
     def get_post_by_url(self, url):
         """
         根据 URL 获取指定文章
@@ -110,26 +159,41 @@ class EmailService:
             dict: 包含文章信息的字典，失败返回 None
         """
         try:
-            feed = feedparser.parse(self.rss_url)
+            normalized = self._normalize_url_for_match(url)
+            if normalized is None:
+                return None
 
+            target_netloc, target_path = normalized
+
+            feed = feedparser.parse(self.rss_url)
             if not feed.entries:
                 return None
 
-            # 标准化 URL 进行匹配
-            target_url = url.rstrip("/")
-
+            matches = []
             for entry in feed.entries:
-                entry_url = entry.link.rstrip("/")
-                # 支持完整 URL 或路径匹配
-                if entry_url == target_url or entry_url.endswith(target_url):
-                    return {
-                        "title": entry.title,
-                        "link": entry.link,
-                        "published": getattr(entry, "published", ""),
-                        "description": getattr(entry, "description", ""),
-                        "summary": getattr(entry, "summary", ""),
-                        "tags": [tag.term for tag in getattr(entry, "tags", [])],
-                    }
+                entry_url = entry.link
+                parsed = urlparse(entry_url)
+                entry_netloc = parsed.netloc.lower()
+                if entry_netloc.startswith("www."):
+                    entry_netloc = entry_netloc[4:]
+                entry_path = _strip_html_suffix(parsed.path.rstrip("/"))
+
+                # path-only 输入：忽略 netloc，仅比对 path
+                # 完整 URL 输入：netloc 与 path 都需匹配
+                netloc_matches = (target_netloc == "") or (target_netloc == entry_netloc)
+                if netloc_matches and target_path == entry_path:
+                    matches.append(entry)
+
+            if len(matches) == 1:
+                entry = matches[0]
+                return {
+                    "title": entry.title,
+                    "link": entry.link,
+                    "published": getattr(entry, "published", ""),
+                    "description": getattr(entry, "description", ""),
+                    "summary": getattr(entry, "summary", ""),
+                    "tags": [tag.term for tag in getattr(entry, "tags", [])],
+                }
 
             return None
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -4,16 +4,15 @@ EmailService get_post_by_url URL 匹配测试
 覆盖: 完整 URL、path-only、裸 slug、index.html 后缀、www 变体、HTTP/HTTPS、多匹配兜底
 """
 
-import sys
+
 from unittest.mock import MagicMock, patch
 
-import feedparser
 import pytest
-
 
 from services.email_service import EmailService, _strip_html_suffix
 
 # ── _strip_html_suffix 单元测试 ──
+
 
 @pytest.mark.parametrize(
     "path, expected",
@@ -149,7 +148,9 @@ def test_get_post_by_url(input_url, expected_title, mock_feed):
     if expected_title is None:
         assert result is None, f"expected None for {input_url!r}, got {result}"
     else:
-        assert result is not None, f"expected {expected_title!r} for {input_url!r}, got None"
+        assert (
+            result is not None
+        ), f"expected {expected_title!r} for {input_url!r}, got None"
         assert result["title"] == expected_title, f"wrong match for {input_url!r}"
 
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,0 +1,180 @@
+# coding: utf-8
+"""
+EmailService get_post_by_url URL 匹配测试
+覆盖: 完整 URL、path-only、裸 slug、index.html 后缀、www 变体、HTTP/HTTPS、多匹配兜底
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import feedparser
+import pytest
+
+
+from services.email_service import EmailService, _strip_html_suffix
+
+# ── _strip_html_suffix 单元测试 ──
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("/p/post-name", "/p/post-name"),
+        ("/p/post-name/index.html", "/p/post-name"),
+        ("/p/post-name/index.htm", "/p/post-name"),
+        ("/p/post-name.html", "/p/post-name"),
+        ("/p/post-name.htm", "/p/post-name"),
+        ("/p/post-name/", "/p/post-name/"),  # trailing slash NOT stripped
+    ],
+)
+def test_strip_html_suffix(path, expected):
+    assert _strip_html_suffix(path) == expected
+
+
+# ── _normalize_url_for_match 单元测试 ──
+
+
+@pytest.mark.parametrize(
+    "raw_url, expected",
+    [
+        # 裸 slug → 拒绝
+        ("正则表达式", None),
+        ("", None),
+        ("   ", None),
+        # path-only
+        ("/p/post-name/", ("", "/p/post-name")),
+        ("/p/post-name", ("", "/p/post-name")),
+        ("/p/post-name/index.html", ("", "/p/post-name")),
+        ("/p/post-name.html", ("", "/p/post-name")),
+        # 完整 URL
+        (
+            "https://svtter.cn/p/post-name/",
+            ("svtter.cn", "/p/post-name"),
+        ),
+        (
+            "https://www.svtter.cn/p/post-name/",
+            ("svtter.cn", "/p/post-name"),
+        ),
+        (
+            "http://svtter.cn/p/post-name/",
+            ("svtter.cn", "/p/post-name"),
+        ),
+        (
+            "https://svtter.cn/p/post-name/index.html",
+            ("svtter.cn", "/p/post-name"),
+        ),
+        # 无 scheme，有 domain 的输入
+        (
+            "svtter.cn/p/post-name/",
+            ("svtter.cn", "/p/post-name"),
+        ),
+    ],
+)
+def test_normalize_url_for_match(raw_url, expected):
+    assert EmailService._normalize_url_for_match(raw_url) == expected
+
+
+# ── get_post_by_url 集成测试（mock feedparser） ──
+
+
+def _make_entry(title, link):
+    """构造一个 mock feedparser entry"""
+    entry = MagicMock()
+    entry.title = title
+    entry.link = link
+    entry.published = "2025-01-01"
+    entry.description = ""
+    entry.summary = ""
+    entry.tags = []
+    return entry
+
+
+def _make_service(rss_url="https://svtter.cn/index.xml"):
+    """构造一个 EmailService 实例（跳过真实初始化）"""
+    svc = EmailService.__new__(EmailService)
+    svc.rss_url = rss_url
+    return svc
+
+
+# 模拟 RSS 条目列表
+ENTRIES = [
+    _make_entry("正则表达式", "https://svtter.cn/p/正则表达式/"),
+    _make_entry("xx正则表达式", "https://svtter.cn/p/xx正则表达式/"),
+    _make_entry("我的正则表达式笔记", "https://svtter.cn/p/我-的-正则表达式-笔记/"),
+    _make_entry("Clean URL article", "https://svtter.cn/post/hello-world/"),
+    _make_entry("Index HTML article", "https://svtter.cn/p/with-index/index.html"),
+]
+
+
+@pytest.fixture
+def mock_feed():
+    """返回一个 mock feed，包含 ENTRYIES"""
+    feed = MagicMock()
+    feed.entries = ENTRIES
+    feed.bozo = False
+    return feed
+
+
+@pytest.mark.parametrize(
+    "input_url, expected_title",
+    [
+        # 完整 URL — 精确匹配
+        ("https://svtter.cn/p/正则表达式/", "正则表达式"),
+        # path-only
+        ("/p/正则表达式/", "正则表达式"),
+        ("/p/正则表达式", "正则表达式"),
+        # 裸 slug → 拒绝
+        ("正则表达式", None),
+        # index.html / .html 后缀
+        ("https://svtter.cn/p/正则表达式/index.html", "正则表达式"),
+        ("https://svtter.cn/p/with-index/index.html", "Index HTML article"),
+        # www 变体
+        ("https://www.svtter.cn/p/正则表达式/", "正则表达式"),
+        # HTTP scheme（非 HTTPS）
+        ("http://svtter.cn/p/正则表达式/", "正则表达式"),
+        # 不同文章 path-only
+        ("/post/hello-world/", "Clean URL article"),
+        ("/post/hello-world", "Clean URL article"),
+        # 无 scheme + domain
+        ("svtter.cn/p/正则表达式/", "正则表达式"),
+        # 无匹配
+        ("https://svtter.cn/p/nonexistent/", None),
+        ("/p/nonexistent/", None),
+    ],
+)
+def test_get_post_by_url(input_url, expected_title, mock_feed):
+    svc = _make_service()
+    with patch("feedparser.parse", return_value=mock_feed):
+        result = svc.get_post_by_url(input_url)
+
+    if expected_title is None:
+        assert result is None, f"expected None for {input_url!r}, got {result}"
+    else:
+        assert result is not None, f"expected {expected_title!r} for {input_url!r}, got None"
+        assert result["title"] == expected_title, f"wrong match for {input_url!r}"
+
+
+def test_get_post_by_url_multiple_matches_returns_none():
+    """当多个条目匹配同一路径时，应返回 None（要求用户更精确）"""
+    dup_entries = [
+        _make_entry("Article A", "https://svtter.cn/p/same-path/"),
+        _make_entry("Article B", "https://svtter.cn/p/same-path/"),
+    ]
+    feed = MagicMock()
+    feed.entries = dup_entries
+    feed.bozo = False
+
+    svc = _make_service()
+    with patch("feedparser.parse", return_value=feed):
+        result = svc.get_post_by_url("/p/same-path/")
+    assert result is None
+
+
+def test_get_post_by_url_empty_feed_returns_none():
+    feed = MagicMock()
+    feed.entries = []
+    feed.bozo = False
+
+    svc = _make_service()
+    with patch("feedparser.parse", return_value=feed):
+        result = svc.get_post_by_url("/p/anything/")
+    assert result is None

--- a/tests/test_email_service_template_vars.py
+++ b/tests/test_email_service_template_vars.py
@@ -3,11 +3,6 @@
 EmailService 模板变量兼容测试
 """
 
-import sys
-import types
-
-sys.modules.setdefault("feedparser", types.SimpleNamespace())
-
 from services.email_service import EmailService
 
 


### PR DESCRIPTION
## Repro

`EmailService.get_post_by_url()` uses `endswith()` to match user input against RSS entry links. This causes:

- **False positives**: bare slug `正则表达式` matches `https://svtter.cn/p/xx正则表达式/` if it appears first in the RSS feed
- **False negatives**: `https://svtter.cn/p/post/index.html` returns None (index.html not stripped), `https://www.svtter.cn/p/post/` returns None (www prefix not normalized), `http://svtter.cn/p/post/` returns None (HTTP scheme)

Reproduced with `python3 /tmp/repro_url_match.py` — 4/11 test cases fail.

## Cause

`services/email_service.py:102-137` — `get_post_by_url()` normalizes only by stripping trailing slashes, then uses `entry_url.endswith(target_url)` which matches any RSS entry whose link ends with the input string, ignoring path boundaries, host variants, scheme, and index.html suffixes.

## Fix

- Added `_strip_html_suffix()` helper to remove trailing index.html, index.htm, .html, .htm from URL paths
- Added `EmailService._normalize_url_for_match()` static method that uses `urllib.parse.urlparse` to extract and normalize netloc (lowercase, strip `www.`) and path (strip trailing slash, strip HTML suffix). Bare slugs (no `/` or `.`) return None.
- Rewrote `get_post_by_url()` to normalize both input and entry URLs, compare netloc+path with exact equality. Path-only inputs match any netloc. Multiple matches return None (caller sees "not found" rather than silent wrong pick).
- Cleaned up `tests/test_email_service_template_vars.py` to remove `sys.modules` pollution
- Added `tests/test_email_service.py` with 33 parametrized cases covering all reported scenarios plus edge cases (multiple matches, empty feed)

## Verification

```
/tmp/test_venv/bin/pytest tests/test_email_service.py tests/test_email_service_template_vars.py -v
============================== 35 passed in 0.75s ==============================
```

Fixes #82