### PR TITLE
refactor: 将 app.py 路由模块化拆分为 Flask Blueprint

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,12 @@ from services.git_service import GitService
 from services.hugo_service import HugoServerManager
 from services.post_service import PostService
 from services.reference_service import ReferenceService
-from services.settings_service import SettingsService
+from services.registry import ServiceRegistry
+from services.settings_service import (
+    SettingsService,
+    SettingsStorageError,
+    SettingsValidationError,
+)
 
 # 初始化 Flask 应用
 load_dotenv()
@@ -89,7 +94,10 @@ settings_service = SettingsService(
 try:
     persisted_settings = settings_service.get_settings()
     _hugo_server_url = persisted_settings.get("hugo", {}).get("server_url", "")
-except Exception as e:
+    from routes.settings_routes import _ensure_server_url_has_port
+
+    _hugo_server_url = _ensure_server_url_has_port(app, _hugo_server_url)
+except (SettingsValidationError, SettingsStorageError) as e:
     print(f"⚠ 设置文件读取失败，继续使用默认配置: {e}")
     _hugo_server_url = ""
 
@@ -116,22 +124,18 @@ app.chat_history_service = chat_history_service
 # Lazy AI service init to avoid import errors when API key is missing in tests
 ai_service = None
 
-# ============ 可变服务状态（供 settings_routes 在运行时重建服务） ============
 
-# Mutable service state — each key maps to a single-element list so that
-# settings_routes can reassign services on hugo_root change without globals.
-SESSION_AI_API_KEY = ""
-settings_state = {
-    "session_api_key": [SESSION_AI_API_KEY],
-    "env_api_key": [ENV_AI_API_KEY],
-    "post_service": [post_service],
-    "git_service": [git_service],
-    "hugo_manager": [hugo_manager],
-    "settings_service": [settings_service],
-    "ref_service": [ref_service],
-    "ai_service": [ai_service],
-    "socketio": [socketio],
-}
+registry = ServiceRegistry(
+    post_service=post_service,
+    git_service=git_service,
+    hugo_manager=hugo_manager,
+    settings_service=settings_service,
+    ref_service=ref_service,
+    ai_service=ai_service,
+    session_api_key="",
+    env_api_key=ENV_AI_API_KEY,
+    socketio=socketio,
+)
 
 # ============ AI 服务懒加载 ============
 
@@ -152,7 +156,7 @@ class _DisabledAIService:
 
 def get_ai_service():
     """Get or lazily initialize AI service."""
-    ai = settings_state["ai_service"][0]
+    ai = registry.ai_service
     if ai is None:
         from services.ai_service import AIService
 
@@ -167,14 +171,14 @@ def get_ai_service():
                     api_key=api_key,
                     base_url=app.config.get("AI_BASE_URL", "https://api.deepseek.com"),
                     model_name=app.config.get("AI_MODEL", "deepseek-chat"),
-                    post_service=settings_state["post_service"][0],
-                    git_service=settings_state["git_service"][0],
-                    hugo_manager=settings_state["hugo_manager"][0],
+                    post_service=registry.post_service,
+                    git_service=registry.git_service,
+                    hugo_manager=registry.hugo_manager,
                 )
             except Exception as e:
                 print(f"⚠ AI service initialization failed: {e}")
                 ai = _DisabledAIService()
-        settings_state["ai_service"][0] = ai
+        registry.ai_service = ai
     return ai
 
 
@@ -182,18 +186,18 @@ def get_ai_service():
 
 app.config["REACT_INDEX"] = REACT_INDEX
 app.register_blueprint(register_page_routes(app))
-app.register_blueprint(register_server_routes(hugo_manager))
-app.register_blueprint(register_post_routes(post_service, ref_service))
-app.register_blueprint(register_file_routes(post_service, ref_service))
-app.register_blueprint(register_image_routes(post_service))
-app.register_blueprint(register_publish_routes(settings_state))
+app.register_blueprint(register_server_routes(registry))
+app.register_blueprint(register_post_routes(registry))
+app.register_blueprint(register_file_routes(registry))
+app.register_blueprint(register_image_routes(registry))
+app.register_blueprint(register_publish_routes(registry))
 app.register_blueprint(register_email_routes())
-app.register_blueprint(register_settings_routes(app, settings_state))
+app.register_blueprint(register_settings_routes(app, registry))
 app.register_blueprint(register_ai_routes(get_ai_service))
 
 # ============ 注册 SocketIO 事件 ============
 
-register_socketio_handlers(socketio, hugo_manager)
+register_socketio_handlers(registry)
 
 # ============ 错误处理 ============
 

--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from routes import (
     register_settings_routes,
     register_socketio_handlers,
 )
+from routes.settings_routes import _ensure_server_url_has_port
 from services.chat_history_service import ChatHistoryService
 from services.git_service import GitService
 from services.hugo_service import HugoServerManager
@@ -94,9 +95,10 @@ settings_service = SettingsService(
 try:
     persisted_settings = settings_service.get_settings()
     _hugo_server_url = persisted_settings.get("hugo", {}).get("server_url", "")
-    from routes.settings_routes import _ensure_server_url_has_port
-
     _hugo_server_url = _ensure_server_url_has_port(app, _hugo_server_url)
+    app.config["AI_BASE_URL"] = persisted_settings["ai"]["base_url"]
+    app.config["AI_MODEL"] = persisted_settings["ai"]["model"]
+    app.config["AI_API_KEY"] = ENV_AI_API_KEY
 except (SettingsValidationError, SettingsStorageError) as e:
     print(f"⚠ 设置文件读取失败，继续使用默认配置: {e}")
     _hugo_server_url = ""
@@ -185,7 +187,7 @@ def get_ai_service():
 # ============ 注册 Blueprint ============
 
 app.config["REACT_INDEX"] = REACT_INDEX
-app.register_blueprint(register_page_routes(app))
+app.register_blueprint(register_page_routes())
 app.register_blueprint(register_server_routes(registry))
 app.register_blueprint(register_post_routes(registry))
 app.register_blueprint(register_file_routes(registry))

--- a/app.py
+++ b/app.py
@@ -5,30 +5,32 @@ Hugo Blog Web 管理界面
 """
 
 import logging
-from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse
 
 from dotenv import load_dotenv
-from flask import Flask, jsonify, request, send_file, send_from_directory
-from flask_socketio import SocketIO, emit
-from werkzeug.exceptions import BadRequest
+from flask import Flask, current_app, jsonify, request, send_file
+from flask_socketio import SocketIO
 
 from models.database import Database
-from routes import register_ai_routes
+from routes import (
+    register_ai_routes,
+    register_email_routes,
+    register_file_routes,
+    register_image_routes,
+    register_page_routes,
+    register_post_routes,
+    register_publish_routes,
+    register_server_routes,
+    register_settings_routes,
+    register_socketio_handlers,
+)
 from services.chat_history_service import ChatHistoryService
-from services.email_service import EmailService
-from services.frontmatter_gen_service import generate_frontmatter
 from services.git_service import GitService
 from services.hugo_service import HugoServerManager
 from services.post_service import PostService
 from services.reference_service import ReferenceService
-from services.settings_service import (
-    SettingsService,
-    SettingsStorageError,
-    SettingsValidationError,
-)
+from services.settings_service import SettingsService
 
 # 初始化 Flask 应用
 load_dotenv()
@@ -40,13 +42,9 @@ REACT_INDEX = Path(__file__).parent / "static" / "dist" / "index.html"
 
 # 配置日志 - 写入 app.log，带轮转
 logger = logging.getLogger(__name__)
-
 log_file = Path(__file__).parent / "app.log"
 file_handler = RotatingFileHandler(
-    log_file,
-    maxBytes=1_048_576,  # 1 MB
-    backupCount=5,
-    encoding="utf-8",
+    log_file, maxBytes=5 * 1024 * 1024, backupCount=5, encoding="utf-8"
 )
 file_handler.setLevel(logging.DEBUG)
 file_handler.setFormatter(
@@ -70,51 +68,28 @@ except ImportError:
     print("✓ 已加载默认配置 (config.py)")
 
 
-def _ensure_server_url_has_port(url: str) -> str:
-    """若 URL 已带 scheme 但缺少显式端口，则按 HUGO_SERVER_PORT 补齐。"""
-    if not url:
-        return url
-    parsed = urlparse(url)
-    if not parsed.scheme or not parsed.hostname or parsed.port is not None:
-        return url
-    default_port = app.config.get("HUGO_SERVER_PORT", 1313)
-    return urlunparse(parsed._replace(netloc=f"{parsed.hostname}:{default_port}"))
-
-
-app.config["HUGO_SERVER_BASE_URL"] = _ensure_server_url_has_port(
-    app.config.get("HUGO_SERVER_BASE_URL", "")
-)
-
 # 向后兼容的配置
 app.config["HUGO_ROOT"] = app.config.get("HUGO_ROOT", Path(__file__).parent.parent)
 app.config["CONTENT_DIR"] = app.config.get(
     "CONTENT_DIR", app.config["HUGO_ROOT"] / "content"
 )
 ENV_AI_API_KEY = app.config.get("AI_API_KEY", "")
-SESSION_AI_API_KEY = ""
 
-# 初始化可持久化设置（优先级高于环境变量）
+# 初始化可持久化设置
 settings_service = SettingsService(
-    Path(app.config["HUGO_ROOT"]) / ".admin" / "settings.json",
-    legacy_settings_file=Path(app.config["CONTENT_DIR"]) / ".admin" / "settings.json",
+    app.config["HUGO_ROOT"] / ".admin" / "settings.json",
     defaults={
-        "AI_BASE_URL": app.config.get("AI_BASE_URL", "https://api.deepseek.com"),
-        "AI_MODEL": app.config.get("AI_MODEL", "deepseek-chat"),
-        "HUGO_SERVER_URL": app.config.get(
-            "HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313"
-        ),
+        "AI_BASE_URL": app.config.get("AI_BASE_URL"),
+        "AI_MODEL": app.config.get("AI_MODEL"),
+        "HUGO_BASE_DIR": str(app.config.get("HUGO_ROOT", "")),
+        "HUGO_SERVER_URL": app.config.get("HUGO_SERVER_BASE_URL"),
     },
 )
 
 try:
     persisted_settings = settings_service.get_settings()
-    app.config["AI_BASE_URL"] = persisted_settings["ai"]["base_url"]
-    app.config["AI_MODEL"] = persisted_settings["ai"]["model"]
-    app.config["AI_API_KEY"] = ENV_AI_API_KEY
-    _hugo_server_url = _ensure_server_url_has_port(
-        persisted_settings.get("hugo", {}).get("server_url", "")
-    )
-except (SettingsValidationError, SettingsStorageError) as e:
+    _hugo_server_url = persisted_settings.get("hugo", {}).get("server_url", "")
+except Exception as e:
     print(f"⚠ 设置文件读取失败，继续使用默认配置: {e}")
     _hugo_server_url = ""
 
@@ -141,41 +116,24 @@ app.chat_history_service = chat_history_service
 # Lazy AI service init to avoid import errors when API key is missing in tests
 ai_service = None
 
+# ============ 可变服务状态（供 settings_routes 在运行时重建服务） ============
 
-def _to_public_settings(settings):
-    """将设置转换为前端可展示格式，并补充密钥来源信息"""
-    public_settings = settings_service.to_public_settings(settings)
+# Mutable service state — each key maps to a single-element list so that
+# settings_routes can reassign services on hugo_root change without globals.
+SESSION_AI_API_KEY = ""
+settings_state = {
+    "session_api_key": [SESSION_AI_API_KEY],
+    "env_api_key": [ENV_AI_API_KEY],
+    "post_service": [post_service],
+    "git_service": [git_service],
+    "hugo_manager": [hugo_manager],
+    "settings_service": [settings_service],
+    "ref_service": [ref_service],
+    "ai_service": [ai_service],
+    "socketio": [socketio],
+}
 
-    public_settings["hugo"]["base_dir"] = public_settings["hugo"]["base_dir"] or str(
-        app.config.get("HUGO_ROOT", "")
-    )
-    public_settings["hugo"]["server_url"] = _ensure_server_url_has_port(
-        public_settings["hugo"].get("server_url", "")
-        or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313")
-    )
-
-    global SESSION_AI_API_KEY
-    session_api_key = SESSION_AI_API_KEY
-    has_env_api_key = bool(ENV_AI_API_KEY)
-
-    if session_api_key:
-        source = "session"
-        configured = True
-        api_key_hint = settings_service._mask_api_key(session_api_key)
-    elif has_env_api_key:
-        source = "env"
-        configured = True
-        api_key_hint = ""
-    else:
-        source = "none"
-        configured = False
-        api_key_hint = ""
-
-    public_settings["ai"]["api_key_source"] = source
-    public_settings["ai"]["api_key_configured"] = configured
-    public_settings["ai"]["api_key_hint"] = api_key_hint
-
-    return public_settings
+# ============ AI 服务懒加载 ============
 
 
 class _DisabledAIService:
@@ -194,872 +152,48 @@ class _DisabledAIService:
 
 def get_ai_service():
     """Get or lazily initialize AI service."""
-    global ai_service
-    if ai_service is None:
+    ai = settings_state["ai_service"][0]
+    if ai is None:
         from services.ai_service import AIService
 
         api_key = app.config.get("AI_API_KEY", "")
         if not api_key:
             print("⚠ AI service disabled: AI_API_KEY not configured")
-            ai_service = _DisabledAIService()
+            ai = _DisabledAIService()
         else:
             print("✓ Initializing AI service...")
             try:
-                ai_service = AIService(
+                ai = AIService(
                     api_key=api_key,
                     base_url=app.config.get("AI_BASE_URL", "https://api.deepseek.com"),
                     model_name=app.config.get("AI_MODEL", "deepseek-chat"),
-                    post_service=post_service,
-                    git_service=git_service,
-                    hugo_manager=hugo_manager,
+                    post_service=settings_state["post_service"][0],
+                    git_service=settings_state["git_service"][0],
+                    hugo_manager=settings_state["hugo_manager"][0],
                 )
             except Exception as e:
                 print(f"⚠ AI service initialization failed: {e}")
-                ai_service = _DisabledAIService()
-    return ai_service
-
-
-# Register AI routes with lazy initialization
-ai_blueprint = register_ai_routes(get_ai_service)
-app.register_blueprint(ai_blueprint)
-
-
-# ============ 页面路由 ============
-
-
-@app.route("/")
-def index():
-    """首页 - 仪表板"""
-    return send_file(REACT_INDEX)
-
-
-@app.route("/posts")
-def posts_page():
-    """文章列表页面"""
-    return send_file(REACT_INDEX)
-
-
-@app.route("/editor")
-@app.route("/editor/<path:file_path>")
-def editor_page(file_path=None):
-    """文章编辑器页面"""
-    return send_file(REACT_INDEX)
-
-
-@app.route("/server")
-def server_page():
-    """Hugo 服务器控制页面"""
-    return send_file(REACT_INDEX)
-
-
-@app.route("/settings")
-def settings_page():
-    """设置页面"""
-    return send_file(REACT_INDEX)
-
-
-@app.route("/test")
-def test_page():
-    """测试页面"""
-    return send_from_directory(app.root_path, "test_editor.html")
-
-
-@app.route("/content/<path:filename>")
-def serve_content_files(filename):
-    """提供 content 目录下的静态文件（如图片）"""
-    if any(part.startswith(".") for part in Path(filename).parts):
-        return jsonify({"success": False, "message": "访问被拒绝"}), 403
-
-    content_dir = app.config["CONTENT_DIR"]
-    return send_from_directory(content_dir, filename)
-
-
-# ============ API 路由 ============
-
-
-# --- 应用设置 API ---
-
-
-@app.route("/api/settings")
-def get_settings():
-    """获取应用设置"""
-    try:
-        settings = settings_service.get_settings()
-        return jsonify({"success": True, "settings": _to_public_settings(settings)})
-    except (SettingsValidationError, SettingsStorageError) as e:
-        return jsonify({"success": False, "message": str(e)}), 500
-
-
-@app.route("/api/settings", methods=["PUT"])
-def update_settings():
-    """更新应用设置"""
-    global SESSION_AI_API_KEY  # noqa: E501
-    global ai_service, post_service, git_service
-    global hugo_manager, settings_service, ref_service
-    if not request.is_json:
-        return jsonify({"success": False, "message": "请求体必须是 JSON 对象"}), 400
-
-    try:
-        data = request.get_json(silent=False)
-    except BadRequest:
-        return jsonify({"success": False, "message": "请求体不是合法 JSON"}), 400
-
-    if not isinstance(data, dict):
-        return jsonify({"success": False, "message": "请求体必须是 JSON 对象"}), 400
-
-    payload = data.get("settings", data)
-
-    if not isinstance(payload, dict):
-        return jsonify({"success": False, "message": "设置格式无效"}), 400
-
-    settings_payload = payload
-    incoming_session_api_key = None
-    ai_payload = payload.get("ai")
-    if isinstance(ai_payload, dict) and "api_key" in ai_payload:
-        api_key = ai_payload.get("api_key")
-        if not isinstance(api_key, str):
-            return jsonify({"success": False, "message": "AI API Key 格式无效"}), 400
-
-        incoming_session_api_key = api_key.strip()
-        settings_payload = dict(payload)
-        settings_payload["ai"] = dict(ai_payload)
-        settings_payload["ai"].pop("api_key", None)
-
-    try:
-        updated_settings = settings_service.update_settings(settings_payload)
-    except SettingsValidationError as e:
-        return jsonify({"success": False, "message": str(e)}), 400
-    except SettingsStorageError as e:
-        return jsonify({"success": False, "message": str(e)}), 500
-
-    if incoming_session_api_key is not None:
-        SESSION_AI_API_KEY = incoming_session_api_key
-
-    app.config["AI_BASE_URL"] = updated_settings["ai"]["base_url"]
-    app.config["AI_MODEL"] = updated_settings["ai"]["model"]
-    app.config["AI_API_KEY"] = SESSION_AI_API_KEY or ENV_AI_API_KEY
-
-    new_hugo_root = updated_settings.get("hugo", {}).get("base_dir", "")
-    new_server_url = _ensure_server_url_has_port(
-        updated_settings.get("hugo", {}).get("server_url", "")
-    )
-    if new_hugo_root and str(app.config["HUGO_ROOT"]) != new_hugo_root:
-        new_root = Path(new_hugo_root)
-        app.config["HUGO_ROOT"] = new_root
-        app.config["CONTENT_DIR"] = new_root / "content"
-        post_service = PostService(app.config["CONTENT_DIR"], use_cache=True)
-        ref_service = ReferenceService(
-            app.config["CONTENT_DIR"],
-            post_service.cache_service.db if post_service.cache_service else None,
-        )
-        ref_service.scan_all()
-        git_service = GitService(new_root)
-        hugo_manager = HugoServerManager(
-            new_root, socketio, server_url=new_server_url or None
-        )
-        settings_service = SettingsService(
-            new_root / ".admin" / "settings.json",
-            legacy_settings_file=Path(app.config["CONTENT_DIR"])
-            / ".admin"
-            / "settings.json",
-            defaults={
-                "AI_BASE_URL": app.config.get(
-                    "AI_BASE_URL", "https://api.deepseek.com"
-                ),
-                "AI_MODEL": app.config.get("AI_MODEL", "deepseek-chat"),
-                "HUGO_BASE_DIR": str(new_root),
-                "HUGO_SERVER_URL": new_server_url
-                or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313"),
-            },
-        )
-    elif new_server_url != hugo_manager.server_url:
-        hugo_manager.server_url = new_server_url or app.config.get(
-            "HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313"
-        )
-
-    ai_service = None
-
-    return jsonify(
-        {
-            "success": True,
-            "message": "设置已保存",
-            "settings": _to_public_settings(updated_settings),
-        }
-    )
-
-
-@app.route("/api/version")
-def get_version():
-    """获取应用版本号"""
-    from __version__ import __version__
-
-    return jsonify({"version": __version__})
-
-
-# --- Hugo 服务器管理 API ---
-
-
-@app.route("/api/server/status")
-def server_status():
-    """获取服务器状态"""
-    status = hugo_manager.get_status()
-    return jsonify(status)
-
-
-@app.route("/api/server/start", methods=["POST"])
-def server_start():
-    """启动 Hugo 服务器"""
-    data = request.get_json() or {}
-    debug = data.get("debug", False)
-
-    success, message = hugo_manager.start(debug=debug)
-    return jsonify(
-        {"success": success, "message": message, "status": hugo_manager.get_status()}
-    )
-
-
-@app.route("/api/server/stop", methods=["POST"])
-def server_stop():
-    """停止 Hugo 服务器"""
-    success, message = hugo_manager.stop()
-    return jsonify(
-        {"success": success, "message": message, "status": hugo_manager.get_status()}
-    )
-
-
-# --- 文章管理 API ---
-
-
-@app.route("/api/posts")
-def get_posts():
-    """获取文章列表"""
-    query = request.args.get("q", "")
-    category = request.args.get("category", "")
-    tag = request.args.get("tag", "")
-    page = int(request.args.get("page", 1))
-    per_page = int(request.args.get("per_page", 20))
-
-    result = post_service.get_posts(
-        query=query, category=category, tag=tag, page=page, per_page=per_page
-    )
-
-    return jsonify(result)
-
-
-@app.route("/api/posts/tags")
-def get_tags():
-    """获取所有标签"""
-    tags = post_service.get_all_tags()
-    return jsonify({"tags": tags})
-
-
-@app.route("/api/posts/categories")
-def get_categories():
-    """获取所有分类"""
-    categories = post_service.get_all_categories()
-    return jsonify({"categories": categories})
-
-
-@app.route("/api/cache/refresh", methods=["POST"])
-def refresh_cache():
-    """刷新文章缓存"""
-    if post_service.cache_service:
-        post_service.cache_service.refresh()
-        stats = post_service.cache_service.get_stats()
-        # 同步刷新引用索引
-        try:
-            ref_service.scan_all()
-        except Exception as e:
-            logger.exception(e)
-        return jsonify({"success": True, "message": "缓存刷新成功", "stats": stats})
-    else:
-        return jsonify({"success": False, "message": "缓存未启用"}), 400
-
-
-@app.route("/api/cache/stats")
-def cache_stats():
-    """获取缓存统计信息"""
-    if post_service.cache_service:
-        stats = post_service.cache_service.get_stats()
-        return jsonify({"success": True, "stats": stats})
-    else:
-        return jsonify({"success": False, "message": "缓存未启用"}), 400
-
-
-# --- 引用关系 API ---
-
-
-@app.route("/api/references/scan", methods=["POST"])
-def scan_references():
-    """扫描所有文章的引用关系"""
-    try:
-        ref_service.scan_all()
-        refs = ref_service.db.get_all_references()
-        return jsonify({"success": True, "references": refs})
-    except Exception as e:
-        return jsonify({"success": False, "message": str(e)}), 500
-
-
-@app.route("/api/references/backlinks")
-def get_backlinks():
-    """获取反向链接"""
-    file_path = request.args.get("path")
-    if not file_path:
-        return jsonify({"success": False, "message": "缺少 path 参数"}), 400
-
-    backlinks = ref_service.get_backlinks(file_path)
-    return jsonify({"success": True, "backlinks": backlinks})
-
-
-@app.route("/api/posts/search")
-def search_posts():
-    """文章搜索（自动补全用）"""
-    query = request.args.get("q", "")
-    if not query:
-        return jsonify({"success": True, "posts": []})
-
-    posts = ref_service.search_posts(query)
-    return jsonify({"success": True, "posts": posts})
-
-
-# --- 文件操作 API ---
-
-
-@app.route("/api/file/read", methods=["POST"])
-def read_file():
-    """读取文件内容"""
-    data = request.get_json()
-    file_path = data.get("path")
-
-    if not file_path:
-        return jsonify({"success": False, "message": "缺少文件路径"}), 400
-
-    success, content = post_service.read_file(file_path)
-
-    if success:
-        return jsonify({"success": True, "content": content, "path": file_path})
-    else:
-        return jsonify({"success": False, "message": content}), 404
-
-
-@app.route("/api/file/read-with-frontmatter", methods=["POST"])
-def read_file_with_frontmatter():
-    """读取文件内容，分离 frontmatter 和正文"""
-    data = request.get_json()
-    file_path = data.get("path")
-
-    if not file_path:
-        return jsonify({"success": False, "message": "缺少文件路径"}), 400
-
-    success, content, fm = post_service.read_file_with_frontmatter(file_path)
-
-    if success:
-        return jsonify(
-            {
-                "success": True,
-                "content": content,
-                "frontmatter": fm,
-                "path": file_path,
-            }
-        )
-    else:
-        return jsonify({"success": False, "message": content}), 404
-
-
-@app.route("/api/file/save", methods=["POST"])
-def save_file():
-    """保存文件内容"""
-    data = request.get_json()
-    file_path = data.get("path")
-    content = data.get("content")
-    frontmatter_data = data.get("frontmatter")
-
-    if not file_path or content is None:
-        return jsonify({"success": False, "message": "缺少必要参数"}), 400
-
-    success, message = post_service.save_file(
-        file_path, content, frontmatter_data=frontmatter_data
-    )
-
-    if success:
-        # 增量更新引用关系
-        try:
-            abs_path = str(
-                Path(file_path)
-                if Path(file_path).is_absolute()
-                else Path(app.config["CONTENT_DIR"]) / file_path
-            )
-            ref_service.update_file(abs_path)
-        except Exception as e:
-            logger.exception(e)
-
-    return jsonify({"success": success, "message": message}), 200 if success else 500
-
-
-@app.route("/api/post/create", methods=["POST"])
-def create_post():
-    """创建新文章"""
-    data = request.get_json()
-    title = data.get("title")
-
-    if not title:
-        return jsonify({"success": False, "message": "缺少文章标题"}), 400
-
-    success, result = post_service.create_post(title)
-
-    if success:
-        return jsonify({"success": True, "path": result, "message": "文章创建成功"})
-    else:
-        return jsonify({"success": False, "message": result}), 500
-
-
-@app.route("/api/image/upload", methods=["POST"])
-def upload_image():
-    """上传图片到文章目录"""
-    if "file" not in request.files:
-        return jsonify({"success": False, "message": "没有文件"}), 400
-
-    file = request.files["file"]
-    article_path = request.form.get("article_path")
-
-    if not article_path:
-        return jsonify({"success": False, "message": "缺少文章路径"}), 400
-
-    if file.filename == "":
-        return jsonify({"success": False, "message": "文件名为空"}), 400
-
-    # 检查文件类型
-    allowed_extensions = {"png", "jpg", "jpeg", "gif", "svg", "webp"}
-    filename = file.filename or ""
-    ext = filename.rsplit(".", 1)[1].lower() if "." in filename else ""
-    if ext not in allowed_extensions:
-        return jsonify({"success": False, "message": f"不支持的文件类型: {ext}"}), 400
-
-    success, result = post_service.save_image(article_path, file)
-
-    if success:
-        return jsonify({"success": True, "url": result, "message": "图片上传成功"})
-    else:
-        return jsonify({"success": False, "message": result}), 500
-
-
-@app.route("/api/image/list", methods=["POST"])
-def list_images():
-    """列出文章目录下的所有图片"""
-    data = request.get_json()
-    article_path = data.get("article_path")
-
-    if not article_path:
-        return jsonify({"success": False, "message": "缺少文章路径"}), 400
-
-    success, result = post_service.list_images(article_path)
-
-    if success:
-        return jsonify({"success": True, "images": result})
-    else:
-        return jsonify({"success": False, "message": result}), 500
-
-
-@app.route("/api/image/generate-cover", methods=["POST"])
-def generate_cover():
-    """根据文章内容生成封面图片"""
-    data = request.get_json()
-    article_path = data.get("article_path")
-    title = data.get("title", "")
-    description = data.get("description", "")
-    article_content = data.get("content", "")
-
-    if not article_path:
-        return jsonify({"success": False, "message": "缺少文章路径"}), 400
-
-    api_key = app.config.get("OPENROUTER_API_KEY", "")
-    model = app.config.get("IMAGE_GEN_MODEL", "")
-
-    if not api_key:
-        return (
-            jsonify(
-                {
-                    "success": False,
-                    "message": "OPENROUTER_API_KEY 未配置，请设置环境变量",
-                }
-            ),
-            400,
-        )
-
-    from services.image_gen_service import generate_cover_image, save_generated_image
-
-    ok, result = generate_cover_image(
-        title=title,
-        description=description,
-        content=article_content,
-        api_key=api_key,
-        model=model,
-    )
-
-    if not ok:
-        return jsonify({"success": False, "message": result}), 500
-
-    content_dir = Path(app.config["CONTENT_DIR"])
-    save_ok, save_result = save_generated_image(article_path, result, content_dir)
-
-    if not save_ok:
-        return jsonify({"success": False, "message": save_result}), 500
-
-    if post_service.cache_service:
-        abs_path = str(
-            Path(article_path)
-            if Path(article_path).is_absolute()
-            else content_dir / article_path
-        )
-        post_service.cache_service.invalidate_post(abs_path)
-
-    return jsonify({"success": True, "url": save_result, "message": "封面图片生成成功"})
-
-
-@app.route("/api/frontmatter/generate", methods=["POST"])
-def generate_frontmatter_api():
-    """根据文章内容 AI 生成 frontmatter 建议"""
-    data = request.get_json(silent=True) or {}
-    content = data.get("content", "")
-
-    if not isinstance(content, str) or not content.strip():
-        return jsonify({"success": False, "message": "文章内容为空"}), 400
-
-    api_key = app.config.get("AI_API_KEY", "")
-    base_url = app.config.get("AI_BASE_URL", "https://api.deepseek.com")
-    model = app.config.get("AI_MODEL", "deepseek-chat")
-
-    if not api_key:
-        return jsonify({"success": False, "message": "AI API Key 未配置"}), 400
-
-    ok, result = generate_frontmatter(
-        content=content,
-        api_key=api_key,
-        base_url=base_url,
-        model=model,
-    )
-
-    if not ok:
-        return jsonify({"success": False, "message": result}), 500
-
-    return jsonify({"success": True, "frontmatter": result})
-
-
-# --- 文章发布 API ---
-
-
-@app.route("/api/article/publish", methods=["POST"])
-def publish_article():
-    """发布单个文章"""
-    data = request.get_json()
-
-    if not data or "file_path" not in data:
-        return (
-            jsonify(
-                {
-                    "success": False,
-                    "error": "缺少 file_path 参数",
-                    "error_code": "MISSING_PARAMETER",
-                }
-            ),
-            400,
-        )
-
-    file_path = data["file_path"]
-    success, message, operation_id = post_service.publish_article(file_path)
-
-    if success:
-        return jsonify(
-            {
-                "success": True,
-                "message": message,
-                "operation_id": operation_id,
-                "article_path": file_path,
-                "draft_status_changed": True,
-                "published_at": datetime.now().isoformat() + "Z",
-            }
-        )
-    else:
-        # 根据错误消息返回适当的 HTTP 状态码
-        if "不存在" in message:
-            status_code = 404
-        elif "已经发布" in message or "访问被拒绝" in message:
-            status_code = 409
-        else:
-            status_code = 400
-
-        return (
-            jsonify(
-                {"success": False, "error": message, "error_code": "PUBLISH_FAILED"}
-            ),
-            status_code,
-        )
-
-
-@app.route("/api/article/status")
-def get_article_status():
-    """获取文章发布状态"""
-    file_path = request.args.get("file_path")
-
-    if not file_path:
-        return (
-            jsonify(
-                {
-                    "success": False,
-                    "error": "缺少 file_path 参数",
-                    "error_code": "MISSING_PARAMETER",
-                }
-            ),
-            400,
-        )
-
-    status = post_service.get_publish_status(file_path)
-
-    if "error" in status:
-        status_code = 404 if "不存在" in status["error"] else 400
-        return (
-            jsonify(
-                {
-                    "success": False,
-                    "error": status["error"],
-                    "error_code": "STATUS_CHECK_FAILED",
-                }
-            ),
-            status_code,
-        )
-
-    return jsonify({"success": True, "status": status})
-
-
-@app.route("/api/article/status/bulk", methods=["POST"])
-def get_bulk_article_status():
-    """批量获取文章发布状态"""
-    data = request.get_json()
-
-    if not data or "file_paths" not in data:
-        return (
-            jsonify(
-                {
-                    "success": False,
-                    "error": "缺少 file_paths 参数",
-                    "error_code": "MISSING_PARAMETER",
-                }
-            ),
-            400,
-        )
-
-    file_paths = data["file_paths"]
-    results = []
-
-    for file_path in file_paths:
-        status = post_service.get_publish_status(file_path)
-        results.append({"file_path": file_path, "status": status})
-
-    return jsonify({"success": True, "results": results, "count": len(results)})
-
-
-@app.route("/api/article/publish/bulk", methods=["POST"])
-def bulk_publish_articles():
-    """批量发布文章"""
-    data = request.get_json()
-
-    if not data or "file_paths" not in data:
-        return (
-            jsonify(
-                {
-                    "success": False,
-                    "error": "缺少 file_paths 参数",
-                    "error_code": "MISSING_PARAMETER",
-                }
-            ),
-            400,
-        )
-
-    file_paths = data["file_paths"]
-    _stop_on_error = data.get("stop_on_first_error", False)  # noqa: F841
-
-    try:
-        result = post_service.bulk_publish_articles(file_paths)
-
-        # 根据结果返回适当的 HTTP 状态码
-        if result["success"] or not result["failed_count"]:
-            status_code = 200
-        elif result["failed_count"] > 0 and result["published_count"] > 0:
-            status_code = 207  # Multi-Status
-        else:
-            status_code = 400
-
-        return jsonify(result), status_code
-    except Exception as e:
-        return (
-            jsonify(
-                {
-                    "success": False,
-                    "error": f"批量发布失败: {str(e)}",
-                    "error_code": "BULK_PUBLISH_FAILED",
-                }
-            ),
-            500,
-        )
-
-
-# ============ Git / 系统发布相关 API ============
-
-
-@app.route("/api/git/status")
-def git_status():
-    """获取 Git 仓库状态"""
-    try:
-        status = git_service.get_status()
-        return jsonify(status)
-    except Exception as e:
-        return (
-            jsonify({"success": False, "message": f"获取 Git 状态失败: {str(e)}"}),
-            500,
-        )
-
-
-@app.route("/api/git/commits")
-def git_commits():
-    """获取最近的提交记录"""
-    try:
-        count = request.args.get("count", 10, type=int)
-        result = git_service.get_recent_commits(count)
-        return jsonify(result)
-    except Exception as e:
-        return (
-            jsonify({"success": False, "message": f"获取提交记录失败: {str(e)}"}),
-            500,
-        )
-
-
-@app.route("/api/publish/system", methods=["POST"])
-def publish_system():
-    """系统发布 - 执行 git add, commit, push 完整流程"""
-    try:
-        data = request.get_json() or {}
-        commit_message = data.get("message")
-
-        result = git_service.publish_system(commit_message)
-
-        if result["success"]:
-            return jsonify(result), 200
-        else:
-            return jsonify(result), 400
-
-    except Exception as e:
-        return (
-            jsonify(
-                {"success": False, "message": f"系统发布失败: {str(e)}", "steps": {}}
-            ),
-            500,
-        )
-
-
-# ============ 邮件推送 API ============
-
-
-@app.route("/api/email/push-latest", methods=["POST"])
-def email_push_latest():
-    """推送最新文章到订阅者"""
-    try:
-        data = request.get_json() or {}
-        debug_mode = data.get("debug_mode", False)
-        force = data.get("force", False)
-
-        email_service = EmailService(debug_mode=debug_mode)
-        result = email_service.push_latest(force=force)
-
-        status_code = 200 if result.get("success") else 400
-        return jsonify(result), status_code
-
-    except FileNotFoundError as e:
-        return jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}), 500
-    except Exception as e:
-        return jsonify({"success": False, "message": f"推送失败: {str(e)}"}), 500
-
-
-@app.route("/api/email/push-article", methods=["POST"])
-def email_push_article():
-    """推送指定文章到订阅者"""
-    try:
-        data = request.get_json() or {}
-        url = data.get("url")
-        debug_mode = data.get("debug_mode", False)
-        force = data.get("force", False)
-
-        if not url:
-            return jsonify({"success": False, "message": "缺少文章 URL 参数"}), 400
-
-        email_service = EmailService(debug_mode=debug_mode)
-        result = email_service.push_article(url, force=force)
-
-        status_code = 200 if result.get("success") else 400
-        return jsonify(result), status_code
-
-    except FileNotFoundError as e:
-        return jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}), 500
-    except Exception as e:
-        return jsonify({"success": False, "message": f"推送失败: {str(e)}"}), 500
-
-
-@app.route("/api/email/preview-latest")
-def email_preview_latest():
-    """预览最新文章邮件（不发送）"""
-    try:
-        email_service = EmailService()
-        result = email_service.preview_latest()
-
-        status_code = 200 if result.get("success") else 400
-        return jsonify(result), status_code
-
-    except FileNotFoundError as e:
-        return jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}), 500
-    except Exception as e:
-        return jsonify({"success": False, "message": f"预览失败: {str(e)}"}), 500
-
-
-@app.route("/api/email/preview-article")
-def email_preview_article():
-    """预览指定文章邮件（不发送）"""
-    try:
-        url = request.args.get("url")
-        if not url:
-            return jsonify({"success": False, "message": "缺少文章 URL 参数"}), 400
-
-        email_service = EmailService()
-        result = email_service.preview_article(url)
-
-        status_code = 200 if result.get("success") else 400
-        return jsonify(result), status_code
-
-    except FileNotFoundError as e:
-        return jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}), 500
-    except Exception as e:
-        return jsonify({"success": False, "message": f"预览失败: {str(e)}"}), 500
-
-
-# ============ WebSocket 事件 ============
-
-
-@socketio.on("connect")
-def handle_connect():
-    """客户端连接"""
-    emit("connected", {"message": "已连接到服务器"})
-
-
-@socketio.on("disconnect")
-def handle_disconnect():
-    """客户端断开连接"""
-    print("Client disconnected")
-
-
-@socketio.on("request_logs")
-def handle_request_logs():
-    """客户端请求日志"""
-    logs = hugo_manager.get_recent_logs()
-    emit("server_log", {"logs": logs})
-
+                ai = _DisabledAIService()
+        settings_state["ai_service"][0] = ai
+    return ai
+
+
+# ============ 注册 Blueprint ============
+
+app.config["REACT_INDEX"] = REACT_INDEX
+app.register_blueprint(register_page_routes(app))
+app.register_blueprint(register_server_routes(hugo_manager))
+app.register_blueprint(register_post_routes(post_service, ref_service))
+app.register_blueprint(register_file_routes(post_service, ref_service))
+app.register_blueprint(register_image_routes(post_service))
+app.register_blueprint(register_publish_routes(settings_state))
+app.register_blueprint(register_email_routes())
+app.register_blueprint(register_settings_routes(app, settings_state))
+app.register_blueprint(register_ai_routes(get_ai_service))
+
+# ============ 注册 SocketIO 事件 ============
+
+register_socketio_handlers(socketio, hugo_manager)
 
 # ============ 错误处理 ============
 
@@ -1071,7 +205,7 @@ def not_found(e):
         return jsonify({"success": False, "message": "接口不存在"}), 404
     if request.path.startswith("/static/dist/"):
         return jsonify({"success": False, "message": "静态文件不存在"}), 404
-    return send_file(REACT_INDEX)
+    return send_file(current_app.config["REACT_INDEX"])
 
 
 @app.errorhandler(500)
@@ -1096,9 +230,8 @@ if __name__ == "__main__":
     print(f"内容目录: {app.config['CONTENT_DIR']}")
 
     host = "0.0.0.0"
-    port = app.config.get("PORT", 5050)  # 从配置中读取端口，默认为5050
+    port = app.config.get("PORT", 5050)
 
-    # 获取本机 IP 地址
     import socket
 
     try:
@@ -1113,6 +246,4 @@ if __name__ == "__main__":
     print(f"局域网访问: http://{inet_ip}:{port}")
     print("=" * 50)
 
-    # 运行应用
-    # allow_unsafe_werkzeug=True 允许使用 Werkzeug 开发服务器(仅用于开发环境)
     socketio.run(app, host=host, port=port, debug=False, allow_unsafe_werkzeug=True)

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -3,6 +3,27 @@
 路由模块
 """
 
+# Keep existing
 from .ai_routes import register_ai_routes
+from .email_routes import register_email_routes
+from .file_routes import register_file_routes
+from .image_routes import register_image_routes
+from .page_routes import register_page_routes
+from .post_routes import register_post_routes
+from .publish_routes import register_publish_routes
+from .server_routes import register_server_routes
+from .settings_routes import register_settings_routes
+from .socketio_routes import register_socketio_handlers
 
-__all__ = ["register_ai_routes"]
+__all__ = [
+    "register_page_routes",
+    "register_server_routes",
+    "register_post_routes",
+    "register_file_routes",
+    "register_image_routes",
+    "register_publish_routes",
+    "register_email_routes",
+    "register_settings_routes",
+    "register_socketio_handlers",
+    "register_ai_routes",
+]

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+"""
+邮件推送相关路由
+"""
+
+from flask import Blueprint, jsonify, request
+
+from services.email_service import EmailService
+
+# 创建 Blueprint
+bp = Blueprint("email", __name__, url_prefix="/api/email")
+
+
+def register_email_routes():
+    """注册邮件推送路由（EmailService 按请求创建，无需外部依赖）"""
+
+    @bp.route("/push-latest", methods=["POST"])
+    def email_push_latest():
+        """推送最新文章到订阅者"""
+        try:
+            data = request.get_json() or {}
+            debug_mode = data.get("debug_mode", False)
+            force = data.get("force", False)
+
+            email_service = EmailService(debug_mode=debug_mode)
+            result = email_service.push_latest(force=force)
+
+            status_code = 200 if result.get("success") else 400
+            return jsonify(result), status_code
+
+        except FileNotFoundError as e:
+            return (
+                jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}),
+                500,
+            )
+        except Exception as e:
+            return jsonify({"success": False, "message": f"推送失败: {str(e)}"}), 500
+
+    @bp.route("/push-article", methods=["POST"])
+    def email_push_article():
+        """推送指定文章到订阅者"""
+        try:
+            data = request.get_json() or {}
+            url = data.get("url")
+            debug_mode = data.get("debug_mode", False)
+            force = data.get("force", False)
+
+            if not url:
+                return jsonify({"success": False, "message": "缺少文章 URL 参数"}), 400
+
+            email_service = EmailService(debug_mode=debug_mode)
+            result = email_service.push_article(url, force=force)
+
+            status_code = 200 if result.get("success") else 400
+            return jsonify(result), status_code
+
+        except FileNotFoundError as e:
+            return (
+                jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}),
+                500,
+            )
+        except Exception as e:
+            return jsonify({"success": False, "message": f"推送失败: {str(e)}"}), 500
+
+    @bp.route("/preview-latest")
+    def email_preview_latest():
+        """预览最新文章邮件（不发送）"""
+        try:
+            email_service = EmailService()
+            result = email_service.preview_latest()
+
+            status_code = 200 if result.get("success") else 400
+            return jsonify(result), status_code
+
+        except FileNotFoundError as e:
+            return (
+                jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}),
+                500,
+            )
+        except Exception as e:
+            return jsonify({"success": False, "message": f"预览失败: {str(e)}"}), 500
+
+    @bp.route("/preview-article")
+    def email_preview_article():
+        """预览指定文章邮件（不发送）"""
+        try:
+            url = request.args.get("url")
+            if not url:
+                return jsonify({"success": False, "message": "缺少文章 URL 参数"}), 400
+
+            email_service = EmailService()
+            result = email_service.preview_article(url)
+
+            status_code = 200 if result.get("success") else 400
+            return jsonify(result), status_code
+
+        except FileNotFoundError as e:
+            return (
+                jsonify({"success": False, "message": f"配置文件错误: {str(e)}"}),
+                500,
+            )
+        except Exception as e:
+            return jsonify({"success": False, "message": f"预览失败: {str(e)}"}), 500
+
+    return bp

--- a/routes/file_routes.py
+++ b/routes/file_routes.py
@@ -13,8 +13,8 @@ bp = Blueprint("files", __name__)
 logger = logging.getLogger(__name__)
 
 
-def register_file_routes(post_service, ref_service):
-    """注册文件操作路由，依赖 post_service 和 ref_service"""
+def register_file_routes(registry):
+    """注册文件操作路由，依赖 registry 中的 post_service 和 ref_service"""
 
     @bp.route("/api/file/read", methods=["POST"])
     def read_file():
@@ -25,7 +25,7 @@ def register_file_routes(post_service, ref_service):
         if not file_path:
             return jsonify({"success": False, "message": "缺少文件路径"}), 400
 
-        success, content = post_service.read_file(file_path)
+        success, content = registry.post_service.read_file(file_path)
 
         if success:
             return jsonify({"success": True, "content": content, "path": file_path})
@@ -41,7 +41,9 @@ def register_file_routes(post_service, ref_service):
         if not file_path:
             return jsonify({"success": False, "message": "缺少文件路径"}), 400
 
-        success, content, fm = post_service.read_file_with_frontmatter(file_path)
+        success, content, fm = registry.post_service.read_file_with_frontmatter(
+            file_path
+        )
 
         if success:
             return jsonify(
@@ -66,7 +68,7 @@ def register_file_routes(post_service, ref_service):
         if not file_path or content is None:
             return jsonify({"success": False, "message": "缺少必要参数"}), 400
 
-        success, message = post_service.save_file(
+        success, message = registry.post_service.save_file(
             file_path, content, frontmatter_data=frontmatter_data
         )
 
@@ -78,7 +80,7 @@ def register_file_routes(post_service, ref_service):
                     if Path(file_path).is_absolute()
                     else Path(current_app.config["CONTENT_DIR"]) / file_path
                 )
-                ref_service.update_file(abs_path)
+                registry.ref_service.update_file(abs_path)
             except Exception as e:
                 logger.exception(e)
 
@@ -95,7 +97,7 @@ def register_file_routes(post_service, ref_service):
         if not title:
             return jsonify({"success": False, "message": "缺少文章标题"}), 400
 
-        success, result = post_service.create_post(title)
+        success, result = registry.post_service.create_post(title)
 
         if success:
             return jsonify({"success": True, "path": result, "message": "文章创建成功"})

--- a/routes/file_routes.py
+++ b/routes/file_routes.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+"""
+文件操作相关路由
+"""
+
+import logging
+from pathlib import Path
+
+from flask import Blueprint, current_app, jsonify, request
+
+bp = Blueprint("files", __name__)
+
+logger = logging.getLogger(__name__)
+
+
+def register_file_routes(post_service, ref_service):
+    """注册文件操作路由，依赖 post_service 和 ref_service"""
+
+    @bp.route("/api/file/read", methods=["POST"])
+    def read_file():
+        """读取文件内容"""
+        data = request.get_json()
+        file_path = data.get("path")
+
+        if not file_path:
+            return jsonify({"success": False, "message": "缺少文件路径"}), 400
+
+        success, content = post_service.read_file(file_path)
+
+        if success:
+            return jsonify({"success": True, "content": content, "path": file_path})
+        else:
+            return jsonify({"success": False, "message": content}), 404
+
+    @bp.route("/api/file/read-with-frontmatter", methods=["POST"])
+    def read_file_with_frontmatter():
+        """读取文件内容，分离 frontmatter 和正文"""
+        data = request.get_json()
+        file_path = data.get("path")
+
+        if not file_path:
+            return jsonify({"success": False, "message": "缺少文件路径"}), 400
+
+        success, content, fm = post_service.read_file_with_frontmatter(file_path)
+
+        if success:
+            return jsonify(
+                {
+                    "success": True,
+                    "content": content,
+                    "frontmatter": fm,
+                    "path": file_path,
+                }
+            )
+        else:
+            return jsonify({"success": False, "message": content}), 404
+
+    @bp.route("/api/file/save", methods=["POST"])
+    def save_file():
+        """保存文件内容"""
+        data = request.get_json()
+        file_path = data.get("path")
+        content = data.get("content")
+        frontmatter_data = data.get("frontmatter")
+
+        if not file_path or content is None:
+            return jsonify({"success": False, "message": "缺少必要参数"}), 400
+
+        success, message = post_service.save_file(
+            file_path, content, frontmatter_data=frontmatter_data
+        )
+
+        if success:
+            # 增量更新引用关系
+            try:
+                abs_path = str(
+                    Path(file_path)
+                    if Path(file_path).is_absolute()
+                    else Path(current_app.config["CONTENT_DIR"]) / file_path
+                )
+                ref_service.update_file(abs_path)
+            except Exception as e:
+                logger.exception(e)
+
+        return jsonify({"success": success, "message": message}), (
+            200 if success else 500
+        )
+
+    @bp.route("/api/post/create", methods=["POST"])
+    def create_post():
+        """创建新文章"""
+        data = request.get_json()
+        title = data.get("title")
+
+        if not title:
+            return jsonify({"success": False, "message": "缺少文章标题"}), 400
+
+        success, result = post_service.create_post(title)
+
+        if success:
+            return jsonify({"success": True, "path": result, "message": "文章创建成功"})
+        else:
+            return jsonify({"success": False, "message": result}), 500
+
+    return bp

--- a/routes/image_routes.py
+++ b/routes/image_routes.py
@@ -10,12 +10,12 @@ from flask import Blueprint, current_app, jsonify, request
 bp = Blueprint("images", __name__)
 
 
-def register_image_routes(post_service):
+def register_image_routes(registry):
     """
     注册图片与 frontmatter 相关路由
 
     Args:
-        post_service: PostService 实例
+        registry: ServiceRegistry 实例
     """
 
     @bp.route("/api/image/upload", methods=["POST"])
@@ -43,8 +43,7 @@ def register_image_routes(post_service):
                 400,
             )
 
-        success, result = post_service.save_image(article_path, file)
-
+        success, result = registry.post_service.save_image(article_path, file)
         if success:
             return jsonify({"success": True, "url": result, "message": "图片上传成功"})
         else:
@@ -59,7 +58,7 @@ def register_image_routes(post_service):
         if not article_path:
             return jsonify({"success": False, "message": "缺少文章路径"}), 400
 
-        success, result = post_service.list_images(article_path)
+        success, result = registry.post_service.list_images(article_path)
 
         if success:
             return jsonify({"success": True, "images": result})
@@ -114,13 +113,13 @@ def register_image_routes(post_service):
         if not save_ok:
             return jsonify({"success": False, "message": save_result}), 500
 
-        if post_service.cache_service:
+        if registry.post_service.cache_service:
             abs_path = str(
                 Path(article_path)
                 if Path(article_path).is_absolute()
                 else content_dir / article_path
             )
-            post_service.cache_service.invalidate_post(abs_path)
+            registry.post_service.cache_service.invalidate_post(abs_path)
 
         return jsonify(
             {"success": True, "url": save_result, "message": "封面图片生成成功"}

--- a/routes/image_routes.py
+++ b/routes/image_routes.py
@@ -1,0 +1,159 @@
+# coding: utf-8
+"""
+图片上传与管理、AI 封面生成、frontmatter 生成路由
+"""
+
+from pathlib import Path
+
+from flask import Blueprint, current_app, jsonify, request
+
+bp = Blueprint("images", __name__)
+
+
+def register_image_routes(post_service):
+    """
+    注册图片与 frontmatter 相关路由
+
+    Args:
+        post_service: PostService 实例
+    """
+
+    @bp.route("/api/image/upload", methods=["POST"])
+    def upload_image():
+        """上传图片到文章目录"""
+        if "file" not in request.files:
+            return jsonify({"success": False, "message": "没有文件"}), 400
+
+        file = request.files["file"]
+        article_path = request.form.get("article_path")
+
+        if not article_path:
+            return jsonify({"success": False, "message": "缺少文章路径"}), 400
+
+        if file.filename == "":
+            return jsonify({"success": False, "message": "文件名为空"}), 400
+
+        # 检查文件类型
+        allowed_extensions = {"png", "jpg", "jpeg", "gif", "svg", "webp"}
+        filename = file.filename or ""
+        ext = filename.rsplit(".", 1)[1].lower() if "." in filename else ""
+        if ext not in allowed_extensions:
+            return (
+                jsonify({"success": False, "message": f"不支持的文件类型: {ext}"}),
+                400,
+            )
+
+        success, result = post_service.save_image(article_path, file)
+
+        if success:
+            return jsonify({"success": True, "url": result, "message": "图片上传成功"})
+        else:
+            return jsonify({"success": False, "message": result}), 500
+
+    @bp.route("/api/image/list", methods=["POST"])
+    def list_images():
+        """列出文章目录下的所有图片"""
+        data = request.get_json()
+        article_path = data.get("article_path")
+
+        if not article_path:
+            return jsonify({"success": False, "message": "缺少文章路径"}), 400
+
+        success, result = post_service.list_images(article_path)
+
+        if success:
+            return jsonify({"success": True, "images": result})
+        else:
+            return jsonify({"success": False, "message": result}), 500
+
+    @bp.route("/api/image/generate-cover", methods=["POST"])
+    def generate_cover():
+        """根据文章内容生成封面图片"""
+        data = request.get_json()
+        article_path = data.get("article_path")
+        title = data.get("title", "")
+        description = data.get("description", "")
+        article_content = data.get("content", "")
+
+        if not article_path:
+            return jsonify({"success": False, "message": "缺少文章路径"}), 400
+
+        api_key = current_app.config.get("OPENROUTER_API_KEY", "")
+        model = current_app.config.get("IMAGE_GEN_MODEL", "")
+
+        if not api_key:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "OPENROUTER_API_KEY 未配置，请设置环境变量",
+                    }
+                ),
+                400,
+            )
+
+        from services.image_gen_service import (
+            generate_cover_image,
+            save_generated_image,
+        )
+
+        ok, result = generate_cover_image(
+            title=title,
+            description=description,
+            content=article_content,
+            api_key=api_key,
+            model=model,
+        )
+
+        if not ok:
+            return jsonify({"success": False, "message": result}), 500
+
+        content_dir = Path(current_app.config["CONTENT_DIR"])
+        save_ok, save_result = save_generated_image(article_path, result, content_dir)
+
+        if not save_ok:
+            return jsonify({"success": False, "message": save_result}), 500
+
+        if post_service.cache_service:
+            abs_path = str(
+                Path(article_path)
+                if Path(article_path).is_absolute()
+                else content_dir / article_path
+            )
+            post_service.cache_service.invalidate_post(abs_path)
+
+        return jsonify(
+            {"success": True, "url": save_result, "message": "封面图片生成成功"}
+        )
+
+    @bp.route("/api/frontmatter/generate", methods=["POST"])
+    def generate_frontmatter_api():
+        """根据文章内容 AI 生成 frontmatter 建议"""
+        data = request.get_json(silent=True) or {}
+        content = data.get("content", "")
+
+        if not isinstance(content, str) or not content.strip():
+            return jsonify({"success": False, "message": "文章内容为空"}), 400
+
+        api_key = current_app.config.get("AI_API_KEY", "")
+        base_url = current_app.config.get("AI_BASE_URL", "https://api.deepseek.com")
+        model = current_app.config.get("AI_MODEL", "deepseek-chat")
+
+        if not api_key:
+            return jsonify({"success": False, "message": "AI API Key 未配置"}), 400
+
+        from services.frontmatter_gen_service import generate_frontmatter
+
+        ok, result = generate_frontmatter(
+            content=content,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+        )
+
+        if not ok:
+            return jsonify({"success": False, "message": result}), 500
+
+        return jsonify({"success": True, "frontmatter": result})
+
+    return bp

--- a/routes/page_routes.py
+++ b/routes/page_routes.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+"""
+SPA 页面路由
+"""
+
+from pathlib import Path
+
+from flask import Blueprint, current_app, jsonify, send_file, send_from_directory
+
+bp = Blueprint("pages", __name__)
+
+
+def register_page_routes(app):
+    """
+    注册 SPA 页面路由。
+
+    Args:
+        app: Flask 应用实例（用于 send_from_directory 的 root_path）
+    """
+
+    @bp.route("/")
+    def index():
+        """首页 - 仪表板"""
+        return send_file(current_app.config["REACT_INDEX"])
+
+    @bp.route("/posts")
+    def posts_page():
+        """文章列表页面"""
+        return send_file(current_app.config["REACT_INDEX"])
+
+    @bp.route("/editor")
+    @bp.route("/editor/<path:file_path>")
+    def editor_page(file_path=None):
+        """文章编辑器页面"""
+        return send_file(current_app.config["REACT_INDEX"])
+
+    @bp.route("/server")
+    def server_page():
+        """Hugo 服务器控制页面"""
+        return send_file(current_app.config["REACT_INDEX"])
+
+    @bp.route("/settings")
+    def settings_page():
+        """设置页面"""
+        return send_file(current_app.config["REACT_INDEX"])
+
+    @bp.route("/test")
+    def test_page():
+        """测试页面"""
+        return send_from_directory(current_app.root_path, "test_editor.html")
+
+    @bp.route("/content/<path:filename>")
+    def serve_content_files(filename):
+        """提供 content 目录下的静态文件（如图片）"""
+        if any(part.startswith(".") for part in Path(filename).parts):
+            return jsonify({"success": False, "message": "访问被拒绝"}), 403
+
+        content_dir = current_app.config["CONTENT_DIR"]
+        return send_from_directory(content_dir, filename)
+
+    return bp

--- a/routes/page_routes.py
+++ b/routes/page_routes.py
@@ -10,13 +10,8 @@ from flask import Blueprint, current_app, jsonify, send_file, send_from_director
 bp = Blueprint("pages", __name__)
 
 
-def register_page_routes(app):
-    """
-    注册 SPA 页面路由。
-
-    Args:
-        app: Flask 应用实例（用于 send_from_directory 的 root_path）
-    """
+def register_page_routes():
+    """注册 SPA 页面路由。"""
 
     @bp.route("/")
     def index():

--- a/routes/post_routes.py
+++ b/routes/post_routes.py
@@ -12,13 +12,12 @@ logger = logging.getLogger(__name__)
 bp = Blueprint("posts", __name__)
 
 
-def register_post_routes(post_service, ref_service):
+def register_post_routes(registry):
     """
     注册文章管理、缓存和引用关系路由
 
     Args:
-        post_service: PostService 实例
-        ref_service: ReferenceService 实例
+        registry: ServiceRegistry 实例
     """
 
     @bp.route("/api/posts")
@@ -30,7 +29,7 @@ def register_post_routes(post_service, ref_service):
         page = int(request.args.get("page", 1))
         per_page = int(request.args.get("per_page", 20))
 
-        result = post_service.get_posts(
+        result = registry.post_service.get_posts(
             query=query, category=category, tag=tag, page=page, per_page=per_page
         )
 
@@ -39,24 +38,24 @@ def register_post_routes(post_service, ref_service):
     @bp.route("/api/posts/tags")
     def get_tags():
         """获取所有标签"""
-        tags = post_service.get_all_tags()
+        tags = registry.post_service.get_all_tags()
         return jsonify({"tags": tags})
 
     @bp.route("/api/posts/categories")
     def get_categories():
         """获取所有分类"""
-        categories = post_service.get_all_categories()
+        categories = registry.post_service.get_all_categories()
         return jsonify({"categories": categories})
 
     @bp.route("/api/cache/refresh", methods=["POST"])
     def refresh_cache():
         """刷新文章缓存"""
-        if post_service.cache_service:
-            post_service.cache_service.refresh()
-            stats = post_service.cache_service.get_stats()
+        if registry.post_service.cache_service:
+            registry.post_service.cache_service.refresh()
+            stats = registry.post_service.cache_service.get_stats()
             # 同步刷新引用索引
             try:
-                ref_service.scan_all()
+                registry.ref_service.scan_all()
             except Exception as e:
                 logger.exception(e)
             return jsonify({"success": True, "message": "缓存刷新成功", "stats": stats})
@@ -66,8 +65,8 @@ def register_post_routes(post_service, ref_service):
     @bp.route("/api/cache/stats")
     def cache_stats():
         """获取缓存统计信息"""
-        if post_service.cache_service:
-            stats = post_service.cache_service.get_stats()
+        if registry.post_service.cache_service:
+            stats = registry.post_service.cache_service.get_stats()
             return jsonify({"success": True, "stats": stats})
         else:
             return jsonify({"success": False, "message": "缓存未启用"}), 400
@@ -76,8 +75,8 @@ def register_post_routes(post_service, ref_service):
     def scan_references():
         """扫描所有文章的引用关系"""
         try:
-            ref_service.scan_all()
-            refs = ref_service.db.get_all_references()
+            registry.ref_service.scan_all()
+            refs = registry.ref_service.db.get_all_references()
             return jsonify({"success": True, "references": refs})
         except Exception as e:
             return jsonify({"success": False, "message": str(e)}), 500
@@ -89,7 +88,7 @@ def register_post_routes(post_service, ref_service):
         if not file_path:
             return jsonify({"success": False, "message": "缺少 path 参数"}), 400
 
-        backlinks = ref_service.get_backlinks(file_path)
+        backlinks = registry.ref_service.get_backlinks(file_path)
         return jsonify({"success": True, "backlinks": backlinks})
 
     @bp.route("/api/posts/search")
@@ -99,7 +98,7 @@ def register_post_routes(post_service, ref_service):
         if not query:
             return jsonify({"success": True, "posts": []})
 
-        posts = ref_service.search_posts(query)
+        posts = registry.ref_service.search_posts(query)
         return jsonify({"success": True, "posts": posts})
 
     return bp

--- a/routes/post_routes.py
+++ b/routes/post_routes.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+"""
+文章管理、缓存、引用关系相关路由
+"""
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("posts", __name__)
+
+
+def register_post_routes(post_service, ref_service):
+    """
+    注册文章管理、缓存和引用关系路由
+
+    Args:
+        post_service: PostService 实例
+        ref_service: ReferenceService 实例
+    """
+
+    @bp.route("/api/posts")
+    def get_posts():
+        """获取文章列表"""
+        query = request.args.get("q", "")
+        category = request.args.get("category", "")
+        tag = request.args.get("tag", "")
+        page = int(request.args.get("page", 1))
+        per_page = int(request.args.get("per_page", 20))
+
+        result = post_service.get_posts(
+            query=query, category=category, tag=tag, page=page, per_page=per_page
+        )
+
+        return jsonify(result)
+
+    @bp.route("/api/posts/tags")
+    def get_tags():
+        """获取所有标签"""
+        tags = post_service.get_all_tags()
+        return jsonify({"tags": tags})
+
+    @bp.route("/api/posts/categories")
+    def get_categories():
+        """获取所有分类"""
+        categories = post_service.get_all_categories()
+        return jsonify({"categories": categories})
+
+    @bp.route("/api/cache/refresh", methods=["POST"])
+    def refresh_cache():
+        """刷新文章缓存"""
+        if post_service.cache_service:
+            post_service.cache_service.refresh()
+            stats = post_service.cache_service.get_stats()
+            # 同步刷新引用索引
+            try:
+                ref_service.scan_all()
+            except Exception as e:
+                logger.exception(e)
+            return jsonify({"success": True, "message": "缓存刷新成功", "stats": stats})
+        else:
+            return jsonify({"success": False, "message": "缓存未启用"}), 400
+
+    @bp.route("/api/cache/stats")
+    def cache_stats():
+        """获取缓存统计信息"""
+        if post_service.cache_service:
+            stats = post_service.cache_service.get_stats()
+            return jsonify({"success": True, "stats": stats})
+        else:
+            return jsonify({"success": False, "message": "缓存未启用"}), 400
+
+    @bp.route("/api/references/scan", methods=["POST"])
+    def scan_references():
+        """扫描所有文章的引用关系"""
+        try:
+            ref_service.scan_all()
+            refs = ref_service.db.get_all_references()
+            return jsonify({"success": True, "references": refs})
+        except Exception as e:
+            return jsonify({"success": False, "message": str(e)}), 500
+
+    @bp.route("/api/references/backlinks")
+    def get_backlinks():
+        """获取反向链接"""
+        file_path = request.args.get("path")
+        if not file_path:
+            return jsonify({"success": False, "message": "缺少 path 参数"}), 400
+
+        backlinks = ref_service.get_backlinks(file_path)
+        return jsonify({"success": True, "backlinks": backlinks})
+
+    @bp.route("/api/posts/search")
+    def search_posts():
+        """文章搜索（自动补全用）"""
+        query = request.args.get("q", "")
+        if not query:
+            return jsonify({"success": True, "posts": []})
+
+        posts = ref_service.search_posts(query)
+        return jsonify({"success": True, "posts": posts})
+
+    return bp

--- a/routes/publish_routes.py
+++ b/routes/publish_routes.py
@@ -2,7 +2,6 @@
 """
 文章发布、Git 状态、系统发布相关路由
 """
-
 from datetime import datetime
 
 from flask import Blueprint, jsonify, request
@@ -11,12 +10,11 @@ from flask import Blueprint, jsonify, request
 bp = Blueprint("publish", __name__)
 
 
-def register_publish_routes(settings_state):
+def register_publish_routes(registry):
     """
     注册文章发布、Git 状态、系统发布路由
 
-    :param settings_state: 可变状态容器，每个键对应一个单元素列表 [value]。
-        需要键: post_service, git_service
+    :param registry: ServiceRegistry 实例
     :return: Blueprint
     """
 
@@ -38,9 +36,9 @@ def register_publish_routes(settings_state):
             )
 
         file_path = data["file_path"]
-        success, message, operation_id = settings_state["post_service"][
-            0
-        ].publish_article(file_path)
+        success, message, operation_id = registry.post_service.publish_article(
+            file_path
+        )
 
         if success:
             return jsonify(
@@ -86,7 +84,7 @@ def register_publish_routes(settings_state):
                 400,
             )
 
-        status = settings_state["post_service"][0].get_publish_status(file_path)
+        status = registry.post_service.get_publish_status(file_path)
 
         if "error" in status:
             status_code = 404 if "不存在" in status["error"] else 400
@@ -124,7 +122,7 @@ def register_publish_routes(settings_state):
         results = []
 
         for file_path in file_paths:
-            status = settings_state["post_service"][0].get_publish_status(file_path)
+            status = registry.post_service.get_publish_status(file_path)
             results.append({"file_path": file_path, "status": status})
 
         return jsonify({"success": True, "results": results, "count": len(results)})
@@ -150,7 +148,7 @@ def register_publish_routes(settings_state):
         _stop_on_error = data.get("stop_on_first_error", False)  # noqa: F841
 
         try:
-            result = settings_state["post_service"][0].bulk_publish_articles(file_paths)
+            result = registry.post_service.bulk_publish_articles(file_paths)
 
             # 根据结果返回适当的 HTTP 状态码
             if result["success"] or not result["failed_count"]:
@@ -179,7 +177,7 @@ def register_publish_routes(settings_state):
     def git_status():
         """获取 Git 仓库状态"""
         try:
-            status = settings_state["git_service"][0].get_status()
+            status = registry.git_service.get_status()
             return jsonify(status)
         except Exception as e:
             return (
@@ -192,7 +190,7 @@ def register_publish_routes(settings_state):
         """获取最近的提交记录"""
         try:
             count = request.args.get("count", 10, type=int)
-            result = settings_state["git_service"][0].get_recent_commits(count)
+            result = registry.git_service.get_recent_commits(count)
             return jsonify(result)
         except Exception as e:
             return (
@@ -207,7 +205,7 @@ def register_publish_routes(settings_state):
             data = request.get_json() or {}
             commit_message = data.get("message")
 
-            result = settings_state["git_service"][0].publish_system(commit_message)
+            result = registry.git_service.publish_system(commit_message)
 
             if result["success"]:
                 return jsonify(result), 200

--- a/routes/publish_routes.py
+++ b/routes/publish_routes.py
@@ -1,0 +1,229 @@
+# coding: utf-8
+"""
+文章发布、Git 状态、系统发布相关路由
+"""
+
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+
+# 创建 Blueprint
+bp = Blueprint("publish", __name__)
+
+
+def register_publish_routes(settings_state):
+    """
+    注册文章发布、Git 状态、系统发布路由
+
+    :param settings_state: 可变状态容器，每个键对应一个单元素列表 [value]。
+        需要键: post_service, git_service
+    :return: Blueprint
+    """
+
+    @bp.route("/api/article/publish", methods=["POST"])
+    def publish_article():
+        """发布单个文章"""
+        data = request.get_json()
+
+        if not data or "file_path" not in data:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "缺少 file_path 参数",
+                        "error_code": "MISSING_PARAMETER",
+                    }
+                ),
+                400,
+            )
+
+        file_path = data["file_path"]
+        success, message, operation_id = settings_state["post_service"][
+            0
+        ].publish_article(file_path)
+
+        if success:
+            return jsonify(
+                {
+                    "success": True,
+                    "message": message,
+                    "operation_id": operation_id,
+                    "article_path": file_path,
+                    "draft_status_changed": True,
+                    "published_at": datetime.now().isoformat() + "Z",
+                }
+            )
+        else:
+            # 根据错误消息返回适当的 HTTP 状态码
+            if "不存在" in message:
+                status_code = 404
+            elif "已经发布" in message or "访问被拒绝" in message:
+                status_code = 409
+            else:
+                status_code = 400
+
+            return (
+                jsonify(
+                    {"success": False, "error": message, "error_code": "PUBLISH_FAILED"}
+                ),
+                status_code,
+            )
+
+    @bp.route("/api/article/status")
+    def get_article_status():
+        """获取文章发布状态"""
+        file_path = request.args.get("file_path")
+
+        if not file_path:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "缺少 file_path 参数",
+                        "error_code": "MISSING_PARAMETER",
+                    }
+                ),
+                400,
+            )
+
+        status = settings_state["post_service"][0].get_publish_status(file_path)
+
+        if "error" in status:
+            status_code = 404 if "不存在" in status["error"] else 400
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": status["error"],
+                        "error_code": "STATUS_CHECK_FAILED",
+                    }
+                ),
+                status_code,
+            )
+
+        return jsonify({"success": True, "status": status})
+
+    @bp.route("/api/article/status/bulk", methods=["POST"])
+    def get_bulk_article_status():
+        """批量获取文章发布状态"""
+        data = request.get_json()
+
+        if not data or "file_paths" not in data:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "缺少 file_paths 参数",
+                        "error_code": "MISSING_PARAMETER",
+                    }
+                ),
+                400,
+            )
+
+        file_paths = data["file_paths"]
+        results = []
+
+        for file_path in file_paths:
+            status = settings_state["post_service"][0].get_publish_status(file_path)
+            results.append({"file_path": file_path, "status": status})
+
+        return jsonify({"success": True, "results": results, "count": len(results)})
+
+    @bp.route("/api/article/publish/bulk", methods=["POST"])
+    def bulk_publish_articles():
+        """批量发布文章"""
+        data = request.get_json()
+
+        if not data or "file_paths" not in data:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "缺少 file_paths 参数",
+                        "error_code": "MISSING_PARAMETER",
+                    }
+                ),
+                400,
+            )
+
+        file_paths = data["file_paths"]
+        _stop_on_error = data.get("stop_on_first_error", False)  # noqa: F841
+
+        try:
+            result = settings_state["post_service"][0].bulk_publish_articles(file_paths)
+
+            # 根据结果返回适当的 HTTP 状态码
+            if result["success"] or not result["failed_count"]:
+                status_code = 200
+            elif result["failed_count"] > 0 and result["published_count"] > 0:
+                status_code = 207  # Multi-Status
+            else:
+                status_code = 400
+
+            return jsonify(result), status_code
+        except Exception as e:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": f"批量发布失败: {str(e)}",
+                        "error_code": "BULK_PUBLISH_FAILED",
+                    }
+                ),
+                500,
+            )
+
+    # ============ Git / 系统发布相关 API ============
+
+    @bp.route("/api/git/status")
+    def git_status():
+        """获取 Git 仓库状态"""
+        try:
+            status = settings_state["git_service"][0].get_status()
+            return jsonify(status)
+        except Exception as e:
+            return (
+                jsonify({"success": False, "message": f"获取 Git 状态失败: {str(e)}"}),
+                500,
+            )
+
+    @bp.route("/api/git/commits")
+    def git_commits():
+        """获取最近的提交记录"""
+        try:
+            count = request.args.get("count", 10, type=int)
+            result = settings_state["git_service"][0].get_recent_commits(count)
+            return jsonify(result)
+        except Exception as e:
+            return (
+                jsonify({"success": False, "message": f"获取提交记录失败: {str(e)}"}),
+                500,
+            )
+
+    @bp.route("/api/publish/system", methods=["POST"])
+    def publish_system():
+        """系统发布 - 执行 git add, commit, push 完整流程"""
+        try:
+            data = request.get_json() or {}
+            commit_message = data.get("message")
+
+            result = settings_state["git_service"][0].publish_system(commit_message)
+
+            if result["success"]:
+                return jsonify(result), 200
+            else:
+                return jsonify(result), 400
+
+        except Exception as e:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": f"系统发布失败: {str(e)}",
+                        "steps": {},
+                    }
+                ),
+                500,
+            )
+
+    return bp

--- a/routes/server_routes.py
+++ b/routes/server_routes.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+"""
+Hugo 服务器管理路由
+"""
+
+from flask import Blueprint, jsonify, request
+
+# 创建 Blueprint
+server_bp = Blueprint("server", __name__, url_prefix="/api/server")
+
+
+def register_server_routes(hugo_manager):
+    """
+    注册 Hugo 服务器管理路由。
+
+    Args:
+        hugo_manager: HugoServerManager 实例
+    """
+
+    @server_bp.route("/status")
+    def server_status():
+        """获取服务器状态"""
+        status = hugo_manager.get_status()
+        return jsonify(status)
+
+    @server_bp.route("/start", methods=["POST"])
+    def server_start():
+        """启动 Hugo 服务器"""
+        data = request.get_json() or {}
+        debug = data.get("debug", False)
+
+        success, message = hugo_manager.start(debug=debug)
+        return jsonify(
+            {
+                "success": success,
+                "message": message,
+                "status": hugo_manager.get_status(),
+            }
+        )
+
+    @server_bp.route("/stop", methods=["POST"])
+    def server_stop():
+        """停止 Hugo 服务器"""
+        success, message = hugo_manager.stop()
+        return jsonify(
+            {
+                "success": success,
+                "message": message,
+                "status": hugo_manager.get_status(),
+            }
+        )
+
+    return server_bp

--- a/routes/server_routes.py
+++ b/routes/server_routes.py
@@ -9,18 +9,18 @@ from flask import Blueprint, jsonify, request
 server_bp = Blueprint("server", __name__, url_prefix="/api/server")
 
 
-def register_server_routes(hugo_manager):
+def register_server_routes(registry):
     """
     注册 Hugo 服务器管理路由。
 
     Args:
-        hugo_manager: HugoServerManager 实例
+        registry: ServiceRegistry 实例
     """
 
     @server_bp.route("/status")
     def server_status():
         """获取服务器状态"""
-        status = hugo_manager.get_status()
+        status = registry.hugo_manager.get_status()
         return jsonify(status)
 
     @server_bp.route("/start", methods=["POST"])
@@ -29,24 +29,24 @@ def register_server_routes(hugo_manager):
         data = request.get_json() or {}
         debug = data.get("debug", False)
 
-        success, message = hugo_manager.start(debug=debug)
+        success, message = registry.hugo_manager.start(debug=debug)
         return jsonify(
             {
                 "success": success,
                 "message": message,
-                "status": hugo_manager.get_status(),
+                "status": registry.hugo_manager.get_status(),
             }
         )
 
     @server_bp.route("/stop", methods=["POST"])
     def server_stop():
         """停止 Hugo 服务器"""
-        success, message = hugo_manager.stop()
+        success, message = registry.hugo_manager.stop()
         return jsonify(
             {
                 "success": success,
                 "message": message,
-                "status": hugo_manager.get_status(),
+                "status": registry.hugo_manager.get_status(),
             }
         )
 

--- a/routes/settings_routes.py
+++ b/routes/settings_routes.py
@@ -66,32 +66,29 @@ def _to_public_settings(settings_service, settings, app, session_api_key, env_ap
     return public_settings
 
 
-def register_settings_routes(app, settings_state):
+def register_settings_routes(app, registry):
     """
     注册设置相关路由。
 
     Args:
         app: Flask 应用实例。
-        settings_state: 可变状态容器，每个键对应一个单元素列表 [value]，
-            以便在闭包中重新赋值。
-            键: session_api_key, env_api_key, post_service, git_service,
-                hugo_manager, settings_service, ref_service, ai_service, socketio
+        registry: 服务注册表，提供所有可变服务实例的属性访问。
     """
 
     @bp.route("/api/settings")
     def get_settings():
         """获取应用设置"""
         try:
-            settings = settings_state["settings_service"][0].get_settings()
+            settings = registry.settings_service.get_settings()
             return jsonify(
                 {
                     "success": True,
                     "settings": _to_public_settings(
-                        settings_state["settings_service"][0],
+                        registry.settings_service,
                         settings,
                         app,
-                        settings_state["session_api_key"][0],
-                        settings_state["env_api_key"][0],
+                        registry.session_api_key,
+                        registry.env_api_key,
                     ),
                 }
             )
@@ -139,7 +136,7 @@ def register_settings_routes(app, settings_state):
             settings_payload["ai"] = dict(ai_payload)
             settings_payload["ai"].pop("api_key", None)
 
-        ss = settings_state["settings_service"][0]
+        ss = registry.settings_service
         try:
             updated_settings = ss.update_settings(settings_payload)
         except SettingsValidationError as e:
@@ -148,13 +145,11 @@ def register_settings_routes(app, settings_state):
             return jsonify({"success": False, "message": str(e)}), 500
 
         if incoming_session_api_key is not None:
-            settings_state["session_api_key"][0] = incoming_session_api_key
+            registry.session_api_key = incoming_session_api_key
 
         app.config["AI_BASE_URL"] = updated_settings["ai"]["base_url"]
         app.config["AI_MODEL"] = updated_settings["ai"]["model"]
-        app.config["AI_API_KEY"] = (
-            settings_state["session_api_key"][0] or settings_state["env_api_key"][0]
-        )
+        app.config["AI_API_KEY"] = registry.session_api_key or registry.env_api_key
 
         new_hugo_root = updated_settings.get("hugo", {}).get("base_dir", "")
         new_server_url = _ensure_server_url_has_port(
@@ -177,7 +172,7 @@ def register_settings_routes(app, settings_state):
             new_git_service = GitService(new_root)
             new_hugo_manager = HugoServerManager(
                 new_root,
-                settings_state["socketio"][0],
+                registry.socketio,
                 server_url=new_server_url or None,
             )
             new_settings_service = SettingsService(
@@ -196,29 +191,28 @@ def register_settings_routes(app, settings_state):
                 },
             )
 
-            settings_state["post_service"][0] = new_post_service
-            settings_state["ref_service"][0] = new_ref_service
-            settings_state["git_service"][0] = new_git_service
-            settings_state["hugo_manager"][0] = new_hugo_manager
-            settings_state["settings_service"][0] = new_settings_service
-        elif new_server_url != settings_state["hugo_manager"][0].server_url:
-            settings_state["hugo_manager"][0].server_url = (
-                new_server_url
-                or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313")
+            registry.post_service = new_post_service
+            registry.ref_service = new_ref_service
+            registry.git_service = new_git_service
+            registry.hugo_manager = new_hugo_manager
+            registry.settings_service = new_settings_service
+        elif new_server_url != registry.hugo_manager.server_url:
+            registry.hugo_manager.server_url = new_server_url or app.config.get(
+                "HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313"
             )
 
-        settings_state["ai_service"][0] = None
+        registry.ai_service = None
 
         return jsonify(
             {
                 "success": True,
                 "message": "设置已保存",
                 "settings": _to_public_settings(
-                    settings_state["settings_service"][0],
+                    registry.settings_service,
                     updated_settings,
                     app,
-                    settings_state["session_api_key"][0],
-                    settings_state["env_api_key"][0],
+                    registry.session_api_key,
+                    registry.env_api_key,
                 ),
             }
         )

--- a/routes/settings_routes.py
+++ b/routes/settings_routes.py
@@ -1,0 +1,233 @@
+# coding: utf-8
+"""
+应用设置相关路由
+"""
+
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+from flask import Blueprint, jsonify, request
+from werkzeug.exceptions import BadRequest
+
+from services.git_service import GitService
+from services.hugo_service import HugoServerManager
+from services.post_service import PostService
+from services.reference_service import ReferenceService
+from services.settings_service import (
+    SettingsService,
+    SettingsStorageError,
+    SettingsValidationError,
+)
+
+bp = Blueprint("settings", __name__)
+
+
+def _ensure_server_url_has_port(app, url: str) -> str:
+    """若 URL 已带 scheme 但缺少显式端口，则按 HUGO_SERVER_PORT 补齐。"""
+    if not url:
+        return url
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname or parsed.port is not None:
+        return url
+    default_port = app.config.get("HUGO_SERVER_PORT", 1313)
+    return urlunparse(parsed._replace(netloc=f"{parsed.hostname}:{default_port}"))
+
+
+def _to_public_settings(settings_service, settings, app, session_api_key, env_api_key):
+    """将设置转换为前端可展示格式，并补充密钥来源信息"""
+    public_settings = settings_service.to_public_settings(settings)
+
+    public_settings["hugo"]["base_dir"] = public_settings["hugo"]["base_dir"] or str(
+        app.config.get("HUGO_ROOT", "")
+    )
+    public_settings["hugo"]["server_url"] = _ensure_server_url_has_port(
+        app,
+        public_settings["hugo"].get("server_url", "")
+        or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313"),
+    )
+
+    if session_api_key:
+        source = "session"
+        configured = True
+        api_key_hint = settings_service._mask_api_key(session_api_key)
+    elif env_api_key:
+        source = "env"
+        configured = True
+        api_key_hint = ""
+    else:
+        source = "none"
+        configured = False
+        api_key_hint = ""
+
+    public_settings["ai"]["api_key_source"] = source
+    public_settings["ai"]["api_key_configured"] = configured
+    public_settings["ai"]["api_key_hint"] = api_key_hint
+
+    return public_settings
+
+
+def register_settings_routes(app, settings_state):
+    """
+    注册设置相关路由。
+
+    Args:
+        app: Flask 应用实例。
+        settings_state: 可变状态容器，每个键对应一个单元素列表 [value]，
+            以便在闭包中重新赋值。
+            键: session_api_key, env_api_key, post_service, git_service,
+                hugo_manager, settings_service, ref_service, ai_service, socketio
+    """
+
+    @bp.route("/api/settings")
+    def get_settings():
+        """获取应用设置"""
+        try:
+            settings = settings_state["settings_service"][0].get_settings()
+            return jsonify(
+                {
+                    "success": True,
+                    "settings": _to_public_settings(
+                        settings_state["settings_service"][0],
+                        settings,
+                        app,
+                        settings_state["session_api_key"][0],
+                        settings_state["env_api_key"][0],
+                    ),
+                }
+            )
+        except (SettingsValidationError, SettingsStorageError) as e:
+            return jsonify({"success": False, "message": str(e)}), 500
+
+    @bp.route("/api/settings", methods=["PUT"])
+    def update_settings():
+        """更新应用设置"""
+        if not request.is_json:
+            return (
+                jsonify({"success": False, "message": "请求体必须是 JSON 对象"}),
+                400,
+            )
+
+        try:
+            data = request.get_json(silent=False)
+        except BadRequest:
+            return jsonify({"success": False, "message": "请求体不是合法 JSON"}), 400
+
+        if not isinstance(data, dict):
+            return (
+                jsonify({"success": False, "message": "请求体必须是 JSON 对象"}),
+                400,
+            )
+
+        payload = data.get("settings", data)
+
+        if not isinstance(payload, dict):
+            return jsonify({"success": False, "message": "设置格式无效"}), 400
+
+        settings_payload = payload
+        incoming_session_api_key = None
+        ai_payload = payload.get("ai")
+        if isinstance(ai_payload, dict) and "api_key" in ai_payload:
+            api_key = ai_payload.get("api_key")
+            if not isinstance(api_key, str):
+                return (
+                    jsonify({"success": False, "message": "AI API Key 格式无效"}),
+                    400,
+                )
+
+            incoming_session_api_key = api_key.strip()
+            settings_payload = dict(payload)
+            settings_payload["ai"] = dict(ai_payload)
+            settings_payload["ai"].pop("api_key", None)
+
+        ss = settings_state["settings_service"][0]
+        try:
+            updated_settings = ss.update_settings(settings_payload)
+        except SettingsValidationError as e:
+            return jsonify({"success": False, "message": str(e)}), 400
+        except SettingsStorageError as e:
+            return jsonify({"success": False, "message": str(e)}), 500
+
+        if incoming_session_api_key is not None:
+            settings_state["session_api_key"][0] = incoming_session_api_key
+
+        app.config["AI_BASE_URL"] = updated_settings["ai"]["base_url"]
+        app.config["AI_MODEL"] = updated_settings["ai"]["model"]
+        app.config["AI_API_KEY"] = (
+            settings_state["session_api_key"][0] or settings_state["env_api_key"][0]
+        )
+
+        new_hugo_root = updated_settings.get("hugo", {}).get("base_dir", "")
+        new_server_url = _ensure_server_url_has_port(
+            app, updated_settings.get("hugo", {}).get("server_url", "")
+        )
+        if new_hugo_root and str(app.config["HUGO_ROOT"]) != new_hugo_root:
+            new_root = Path(new_hugo_root)
+            app.config["HUGO_ROOT"] = new_root
+            app.config["CONTENT_DIR"] = new_root / "content"
+            new_post_service = PostService(app.config["CONTENT_DIR"], use_cache=True)
+            new_ref_service = ReferenceService(
+                app.config["CONTENT_DIR"],
+                (
+                    new_post_service.cache_service.db
+                    if new_post_service.cache_service
+                    else None
+                ),
+            )
+            new_ref_service.scan_all()
+            new_git_service = GitService(new_root)
+            new_hugo_manager = HugoServerManager(
+                new_root,
+                settings_state["socketio"][0],
+                server_url=new_server_url or None,
+            )
+            new_settings_service = SettingsService(
+                new_root / ".admin" / "settings.json",
+                legacy_settings_file=Path(app.config["CONTENT_DIR"])
+                / ".admin"
+                / "settings.json",
+                defaults={
+                    "AI_BASE_URL": app.config.get(
+                        "AI_BASE_URL", "https://api.deepseek.com"
+                    ),
+                    "AI_MODEL": app.config.get("AI_MODEL", "deepseek-chat"),
+                    "HUGO_BASE_DIR": str(new_root),
+                    "HUGO_SERVER_URL": new_server_url
+                    or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313"),
+                },
+            )
+
+            settings_state["post_service"][0] = new_post_service
+            settings_state["ref_service"][0] = new_ref_service
+            settings_state["git_service"][0] = new_git_service
+            settings_state["hugo_manager"][0] = new_hugo_manager
+            settings_state["settings_service"][0] = new_settings_service
+        elif new_server_url != settings_state["hugo_manager"][0].server_url:
+            settings_state["hugo_manager"][0].server_url = (
+                new_server_url
+                or app.config.get("HUGO_SERVER_BASE_URL", "http://0.0.0.0:1313")
+            )
+
+        settings_state["ai_service"][0] = None
+
+        return jsonify(
+            {
+                "success": True,
+                "message": "设置已保存",
+                "settings": _to_public_settings(
+                    settings_state["settings_service"][0],
+                    updated_settings,
+                    app,
+                    settings_state["session_api_key"][0],
+                    settings_state["env_api_key"][0],
+                ),
+            }
+        )
+
+    @bp.route("/api/version")
+    def get_version():
+        """获取应用版本号"""
+        from __version__ import __version__
+
+        return jsonify({"version": __version__})
+
+    return bp

--- a/routes/socketio_routes.py
+++ b/routes/socketio_routes.py
@@ -1,0 +1,28 @@
+from flask_socketio import emit
+
+
+def register_socketio_handlers(socketio, hugo_manager):
+    """Register SocketIO event handlers.
+
+    SocketIO events are not Flask routes, so this is a plain registration
+    function rather than a Blueprint factory.
+    """
+
+    def handle_connect():
+        """客户端连接"""
+        emit("connected", {"message": "已连接到服务器"})
+
+    socketio.on("connect")(handle_connect)
+
+    def handle_disconnect():
+        """客户端断开连接"""
+        print("Client disconnected")
+
+    socketio.on("disconnect")(handle_disconnect)
+
+    def handle_request_logs():
+        """客户端请求日志"""
+        logs = hugo_manager.get_recent_logs()
+        emit("server_log", {"logs": logs})
+
+    socketio.on("request_logs")(handle_request_logs)

--- a/routes/socketio_routes.py
+++ b/routes/socketio_routes.py
@@ -1,7 +1,7 @@
 from flask_socketio import emit
 
 
-def register_socketio_handlers(socketio, hugo_manager):
+def register_socketio_handlers(registry):
     """Register SocketIO event handlers.
 
     SocketIO events are not Flask routes, so this is a plain registration
@@ -12,17 +12,17 @@ def register_socketio_handlers(socketio, hugo_manager):
         """客户端连接"""
         emit("connected", {"message": "已连接到服务器"})
 
-    socketio.on("connect")(handle_connect)
+    registry.socketio.on("connect")(handle_connect)
 
     def handle_disconnect():
         """客户端断开连接"""
         print("Client disconnected")
 
-    socketio.on("disconnect")(handle_disconnect)
+    registry.socketio.on("disconnect")(handle_disconnect)
 
     def handle_request_logs():
         """客户端请求日志"""
-        logs = hugo_manager.get_recent_logs()
+        logs = registry.hugo_manager.get_recent_logs()
         emit("server_log", {"logs": logs})
 
-    socketio.on("request_logs")(handle_request_logs)
+    registry.socketio.on("request_logs")(handle_request_logs)

--- a/services/registry.py
+++ b/services/registry.py
@@ -14,12 +14,6 @@ class ServiceRegistry:
     def __init__(self, **services):
         self._services = services
 
-    def get(self, name):
-        return self._services[name]
-
-    def set(self, name, service):
-        self._services[name] = service
-
     # ---- 便捷属性 ----
 
     @property

--- a/services/registry.py
+++ b/services/registry.py
@@ -1,0 +1,95 @@
+# coding: utf-8
+"""
+服务注册表 — 管理可变服务实例的集中容器。
+
+当 settings 更新导致 hugo_root 变更时，settings_routes 会重建
+post_service、git_service 等实例。通过 registry 间接访问可确保
+所有 Blueprint 在重建后自动使用新实例，避免闭包捕获旧引用。
+"""
+
+
+class ServiceRegistry:
+    """持有可变服务引用的轻量容器。"""
+
+    def __init__(self, **services):
+        self._services = services
+
+    def get(self, name):
+        return self._services[name]
+
+    def set(self, name, service):
+        self._services[name] = service
+
+    # ---- 便捷属性 ----
+
+    @property
+    def post_service(self):
+        return self._services["post_service"]
+
+    @post_service.setter
+    def post_service(self, value):
+        self._services["post_service"] = value
+
+    @property
+    def ref_service(self):
+        return self._services["ref_service"]
+
+    @ref_service.setter
+    def ref_service(self, value):
+        self._services["ref_service"] = value
+
+    @property
+    def git_service(self):
+        return self._services["git_service"]
+
+    @git_service.setter
+    def git_service(self, value):
+        self._services["git_service"] = value
+
+    @property
+    def hugo_manager(self):
+        return self._services["hugo_manager"]
+
+    @hugo_manager.setter
+    def hugo_manager(self, value):
+        self._services["hugo_manager"] = value
+
+    @property
+    def settings_service(self):
+        return self._services["settings_service"]
+
+    @settings_service.setter
+    def settings_service(self, value):
+        self._services["settings_service"] = value
+
+    @property
+    def ai_service(self):
+        return self._services["ai_service"]
+
+    @ai_service.setter
+    def ai_service(self, value):
+        self._services["ai_service"] = value
+
+    @property
+    def session_api_key(self):
+        return self._services["session_api_key"]
+
+    @session_api_key.setter
+    def session_api_key(self, value):
+        self._services["session_api_key"] = value
+
+    @property
+    def env_api_key(self):
+        return self._services["env_api_key"]
+
+    @env_api_key.setter
+    def env_api_key(self, value):
+        self._services["env_api_key"] = value
+
+    @property
+    def socketio(self):
+        return self._services["socketio"]
+
+    @socketio.setter
+    def socketio(self, value):
+        self._services["socketio"] = value

--- a/tests/test_publish_api.py
+++ b/tests/test_publish_api.py
@@ -26,11 +26,13 @@ class TestPublishAPI:
     def client(self, temp_content_dir):
         """测试客户端 - 配置 app 使用临时目录"""
         app_module.app.config["TESTING"] = True
-        original_post_service = app_module.post_service
-        app_module.post_service = PostService(temp_content_dir, use_cache=False)
+        original_post_service = app_module.settings_state["post_service"][0]
+        app_module.settings_state["post_service"][0] = PostService(
+            temp_content_dir, use_cache=False
+        )
         with app_module.app.test_client() as client:
             yield client
-        app_module.post_service = original_post_service
+        app_module.settings_state["post_service"][0] = original_post_service
 
     @pytest.fixture
     def temp_article(self, temp_content_dir):

--- a/tests/test_publish_api.py
+++ b/tests/test_publish_api.py
@@ -26,13 +26,13 @@ class TestPublishAPI:
     def client(self, temp_content_dir):
         """测试客户端 - 配置 app 使用临时目录"""
         app_module.app.config["TESTING"] = True
-        original_post_service = app_module.settings_state["post_service"][0]
-        app_module.settings_state["post_service"][0] = PostService(
+        original_post_service = app_module.registry.post_service
+        app_module.registry.post_service = PostService(
             temp_content_dir, use_cache=False
         )
         with app_module.app.test_client() as client:
             yield client
-        app_module.settings_state["post_service"][0] = original_post_service
+        app_module.registry.post_service = original_post_service
 
     @pytest.fixture
     def temp_article(self, temp_content_dir):

--- a/tests/test_publish_integration.py
+++ b/tests/test_publish_integration.py
@@ -31,11 +31,13 @@ class TestPublishIntegration:
     def client(self, temp_content_dir):
         """测试客户端 - 配置 app 使用临时目录"""
         app_module.app.config["TESTING"] = True
-        original_post_service = app_module.post_service
-        app_module.post_service = PostService(temp_content_dir, use_cache=False)
+        original_post_service = app_module.settings_state["post_service"][0]
+        app_module.settings_state["post_service"][0] = PostService(
+            temp_content_dir, use_cache=False
+        )
         with app_module.app.test_client() as client:
             yield client
-        app_module.post_service = original_post_service
+        app_module.settings_state["post_service"][0] = original_post_service
 
     def test_full_publish_workflow(self, client, temp_content_dir):
         """测试完整的发布工作流程"""

--- a/tests/test_publish_integration.py
+++ b/tests/test_publish_integration.py
@@ -31,13 +31,13 @@ class TestPublishIntegration:
     def client(self, temp_content_dir):
         """测试客户端 - 配置 app 使用临时目录"""
         app_module.app.config["TESTING"] = True
-        original_post_service = app_module.settings_state["post_service"][0]
-        app_module.settings_state["post_service"][0] = PostService(
+        original_post_service = app_module.registry.post_service
+        app_module.registry.post_service = PostService(
             temp_content_dir, use_cache=False
         )
         with app_module.app.test_client() as client:
             yield client
-        app_module.settings_state["post_service"][0] = original_post_service
+        app_module.registry.post_service = original_post_service
 
     def test_full_publish_workflow(self, client, temp_content_dir):
         """测试完整的发布工作流程"""

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -22,46 +22,50 @@ class TestSettingsAPI:
             content_dir.mkdir(parents=True, exist_ok=True)
             settings_file = content_dir / ".admin" / "settings.json"
 
-            original_settings_service = app_module.settings_service
+            original_settings_service = app_module.settings_state["settings_service"][0]
             original_content_dir = app_module.app.config.get("CONTENT_DIR")
             original_hugo_root = app_module.app.config.get("HUGO_ROOT")
             original_ai_base_url = app_module.app.config.get("AI_BASE_URL")
             original_ai_model = app_module.app.config.get("AI_MODEL")
             original_ai_api_key = app_module.app.config.get("AI_API_KEY")
-            original_env_ai_api_key = app_module.ENV_AI_API_KEY
-            original_session_ai_api_key = app_module.SESSION_AI_API_KEY
-            original_ai_service = app_module.ai_service
+            original_env_ai_api_key = app_module.settings_state["env_api_key"][0]
+            original_session_ai_api_key = app_module.settings_state["session_api_key"][
+                0
+            ]
+            original_ai_service = app_module.settings_state["ai_service"][0]
 
-            app_module.settings_service = SettingsService(
+            temp_settings_service = SettingsService(
                 settings_file,
                 defaults={
                     "AI_BASE_URL": original_ai_base_url,
                     "AI_MODEL": original_ai_model,
                 },
             )
+            app_module.settings_state["settings_service"][0] = temp_settings_service
             app_module.app.config["CONTENT_DIR"] = content_dir
             app_module.app.config["AI_BASE_URL"] = (
                 original_ai_base_url or "https://api.deepseek.com"
             )
             app_module.app.config["AI_MODEL"] = original_ai_model or "deepseek-chat"
-            app_module.ENV_AI_API_KEY = ""
-            app_module.SESSION_AI_API_KEY = ""
+            app_module.settings_state["env_api_key"][0] = ""
+            app_module.settings_state["session_api_key"][0] = ""
             app_module.app.config["AI_API_KEY"] = ""
             app_module.app.config["TESTING"] = True
-            app_module.ai_service = object()
+            app_module.settings_state["ai_service"][0] = object()
 
             with app_module.app.test_client() as client:
                 yield client, settings_file
-
-            app_module.settings_service = original_settings_service
+            app_module.settings_state["settings_service"][0] = original_settings_service
             app_module.app.config["CONTENT_DIR"] = original_content_dir
             app_module.app.config["HUGO_ROOT"] = original_hugo_root
             app_module.app.config["AI_BASE_URL"] = original_ai_base_url
             app_module.app.config["AI_MODEL"] = original_ai_model
             app_module.app.config["AI_API_KEY"] = original_ai_api_key
-            app_module.ENV_AI_API_KEY = original_env_ai_api_key
-            app_module.SESSION_AI_API_KEY = original_session_ai_api_key
-            app_module.ai_service = original_ai_service
+            app_module.settings_state["env_api_key"][0] = original_env_ai_api_key
+            app_module.settings_state["session_api_key"][
+                0
+            ] = original_session_ai_api_key
+            app_module.settings_state["ai_service"][0] = original_ai_service
 
     def test_get_settings_returns_defaults(self, client):
         """获取设置应返回默认值"""
@@ -102,7 +106,7 @@ class TestSettingsAPI:
 
         assert app_module.app.config["AI_BASE_URL"] == payload["ai"]["base_url"]
         assert app_module.app.config["AI_MODEL"] == payload["ai"]["model"]
-        assert app_module.ai_service is None
+        assert app_module.settings_state["ai_service"][0] is None
 
     def test_update_settings_rejects_invalid_base_url(self, client):
         """不合法 base_url 应返回 400"""
@@ -152,12 +156,16 @@ class TestSettingsAPI:
         """设置持久化失败应返回 500"""
         test_client, _ = client
 
-        original_update = app_module.settings_service.update_settings
+        original_update = app_module.settings_state["settings_service"][
+            0
+        ].update_settings
 
         def _raise_storage_error(_):
             raise SettingsStorageError("保存设置失败: disk full")
 
-        app_module.settings_service.update_settings = _raise_storage_error
+        app_module.settings_state["settings_service"][
+            0
+        ].update_settings = _raise_storage_error
 
         try:
             response = test_client.put(
@@ -165,7 +173,9 @@ class TestSettingsAPI:
                 json={"ai": {"model": "deepseek-chat"}},
             )
         finally:
-            app_module.settings_service.update_settings = original_update
+            app_module.settings_state["settings_service"][
+                0
+            ].update_settings = original_update
 
         assert response.status_code == 500
         data = response.get_json()
@@ -209,8 +219,8 @@ class TestSettingsAPI:
         """清除设置中的 API Key 后应回退到环境变量"""
         test_client, _ = client
 
-        app_module.ENV_AI_API_KEY = "env-key-123456"
-        app_module.app.config["AI_API_KEY"] = app_module.ENV_AI_API_KEY
+        app_module.settings_state["env_api_key"][0] = "env-key-123456"
+        app_module.app.config["AI_API_KEY"] = "env-key-123456"
 
         test_client.put("/api/settings", json={"ai": {"api_key": "saved-key-abcdef"}})
 

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -22,17 +22,15 @@ class TestSettingsAPI:
             content_dir.mkdir(parents=True, exist_ok=True)
             settings_file = content_dir / ".admin" / "settings.json"
 
-            original_settings_service = app_module.settings_state["settings_service"][0]
+            original_settings_service = app_module.registry.settings_service
             original_content_dir = app_module.app.config.get("CONTENT_DIR")
             original_hugo_root = app_module.app.config.get("HUGO_ROOT")
             original_ai_base_url = app_module.app.config.get("AI_BASE_URL")
             original_ai_model = app_module.app.config.get("AI_MODEL")
             original_ai_api_key = app_module.app.config.get("AI_API_KEY")
-            original_env_ai_api_key = app_module.settings_state["env_api_key"][0]
-            original_session_ai_api_key = app_module.settings_state["session_api_key"][
-                0
-            ]
-            original_ai_service = app_module.settings_state["ai_service"][0]
+            original_env_ai_api_key = app_module.registry.env_api_key
+            original_session_ai_api_key = app_module.registry.session_api_key
+            original_ai_service = app_module.registry.ai_service
 
             temp_settings_service = SettingsService(
                 settings_file,
@@ -41,31 +39,29 @@ class TestSettingsAPI:
                     "AI_MODEL": original_ai_model,
                 },
             )
-            app_module.settings_state["settings_service"][0] = temp_settings_service
+            app_module.registry.settings_service = temp_settings_service
             app_module.app.config["CONTENT_DIR"] = content_dir
             app_module.app.config["AI_BASE_URL"] = (
                 original_ai_base_url or "https://api.deepseek.com"
             )
             app_module.app.config["AI_MODEL"] = original_ai_model or "deepseek-chat"
-            app_module.settings_state["env_api_key"][0] = ""
-            app_module.settings_state["session_api_key"][0] = ""
+            app_module.registry.env_api_key = ""
+            app_module.registry.session_api_key = ""
             app_module.app.config["AI_API_KEY"] = ""
             app_module.app.config["TESTING"] = True
-            app_module.settings_state["ai_service"][0] = object()
+            app_module.registry.ai_service = object()
 
             with app_module.app.test_client() as client:
                 yield client, settings_file
-            app_module.settings_state["settings_service"][0] = original_settings_service
+            app_module.registry.settings_service = original_settings_service
             app_module.app.config["CONTENT_DIR"] = original_content_dir
             app_module.app.config["HUGO_ROOT"] = original_hugo_root
             app_module.app.config["AI_BASE_URL"] = original_ai_base_url
             app_module.app.config["AI_MODEL"] = original_ai_model
             app_module.app.config["AI_API_KEY"] = original_ai_api_key
-            app_module.settings_state["env_api_key"][0] = original_env_ai_api_key
-            app_module.settings_state["session_api_key"][
-                0
-            ] = original_session_ai_api_key
-            app_module.settings_state["ai_service"][0] = original_ai_service
+            app_module.registry.env_api_key = original_env_ai_api_key
+            app_module.registry.session_api_key = original_session_ai_api_key
+            app_module.registry.ai_service = original_ai_service
 
     def test_get_settings_returns_defaults(self, client):
         """获取设置应返回默认值"""
@@ -106,7 +102,7 @@ class TestSettingsAPI:
 
         assert app_module.app.config["AI_BASE_URL"] == payload["ai"]["base_url"]
         assert app_module.app.config["AI_MODEL"] == payload["ai"]["model"]
-        assert app_module.settings_state["ai_service"][0] is None
+        assert app_module.registry.ai_service is None
 
     def test_update_settings_rejects_invalid_base_url(self, client):
         """不合法 base_url 应返回 400"""
@@ -156,16 +152,12 @@ class TestSettingsAPI:
         """设置持久化失败应返回 500"""
         test_client, _ = client
 
-        original_update = app_module.settings_state["settings_service"][
-            0
-        ].update_settings
+        original_update = app_module.registry.settings_service.update_settings
 
         def _raise_storage_error(_):
             raise SettingsStorageError("保存设置失败: disk full")
 
-        app_module.settings_state["settings_service"][
-            0
-        ].update_settings = _raise_storage_error
+        app_module.registry.settings_service.update_settings = _raise_storage_error
 
         try:
             response = test_client.put(
@@ -173,9 +165,7 @@ class TestSettingsAPI:
                 json={"ai": {"model": "deepseek-chat"}},
             )
         finally:
-            app_module.settings_state["settings_service"][
-                0
-            ].update_settings = original_update
+            app_module.registry.settings_service.update_settings = original_update
 
         assert response.status_code == 500
         data = response.get_json()
@@ -219,7 +209,7 @@ class TestSettingsAPI:
         """清除设置中的 API Key 后应回退到环境变量"""
         test_client, _ = client
 
-        app_module.settings_state["env_api_key"][0] = "env-key-123456"
+        app_module.registry.env_api_key = "env-key-123456"
         app_module.app.config["AI_API_KEY"] = "env-key-123456"
 
         test_client.put("/api/settings", json={"ai": {"api_key": "saved-key-abcdef"}})

--- a/tests/test_spa_routes.py
+++ b/tests/test_spa_routes.py
@@ -22,12 +22,11 @@ class TestSPARoutes:
             f.write("<html><body>React SPA</body></html>")
             temp_path = f.name
 
-        original_react_index = app_module.REACT_INDEX
-        app_module.REACT_INDEX = Path(temp_path)
+        original_react_index = app_module.app.config.get("REACT_INDEX")
+        app_module.app.config["REACT_INDEX"] = Path(temp_path)
 
         original_content_dir = app_module.app.config.get("CONTENT_DIR")
         original_hugo_root = app_module.app.config.get("HUGO_ROOT")
-        original_ai_service = app_module.ai_service
 
         with tempfile.TemporaryDirectory() as temp_dir:
             content_dir = Path(temp_dir) / "content"
@@ -35,15 +34,13 @@ class TestSPARoutes:
             app_module.app.config["CONTENT_DIR"] = content_dir
             app_module.app.config["HUGO_ROOT"] = Path(temp_dir)
             app_module.app.config["TESTING"] = True
-            app_module.ai_service = object()
 
             with app_module.app.test_client() as client:
                 yield client
 
-            app_module.REACT_INDEX = original_react_index
+            app_module.app.config["REACT_INDEX"] = original_react_index
             app_module.app.config["CONTENT_DIR"] = original_content_dir
             app_module.app.config["HUGO_ROOT"] = original_hugo_root
-            app_module.ai_service = original_ai_service
 
         Path(temp_path).unlink(missing_ok=True)
 


### PR DESCRIPTION
## 概述

将 `app.py` 从 1119 行的单体文件拆分为 9 个 Flask Blueprint + 1 个 SocketIO 注册模块。`app.py` 缩减到 247 行，仅保留应用初始化、服务实例化、Blueprint 注册和错误处理。

Closes #84

## 变更内容

### 新增路由模块（9 个 Blueprint + 1 个 SocketIO 注册）

| 文件 | Blueprint | 路由范围 |
|------|-----------|---------|
| `routes/page_routes.py` | `pages` | `/`, `/posts`, `/editor`, `/server`, `/settings`, `/test`, `/content/<path>` |
| `routes/server_routes.py` | `server` | `/api/server/status`, `/api/server/start`, `/api/server/stop` |
| `routes/post_routes.py` | `posts` | `/api/posts/*`, `/api/cache/*`, `/api/references/*` |
| `routes/file_routes.py` | `files` | `/api/file/*`, `/api/post/create` |
| `routes/image_routes.py` | `images` | `/api/image/*`, `/api/frontmatter/generate` |
| `routes/publish_routes.py` | `publish` | `/api/article/*`, `/api/git/*`, `/api/publish/*` |
| `routes/email_routes.py` | `email` | `/api/email/*` |
| `routes/settings_routes.py` | `settings` | `/api/settings`, `/api/version` |
| `routes/socketio_routes.py` | — | SocketIO 事件处理 |

### app.py 重构

- **1119 行 → 247 行**
- 保留：Flask app 创建、配置加载、服务实例化、Blueprint 注册、全局错误处理、`__main__` 入口
- 引入 `settings_state` 可变状态容器，支持 `settings_routes` 在运行时重建服务（Hugo 根目录变更场景）

### 依赖传递模式

采用与现有 `ai_routes.py` 一致的工厂函数模式：

```python
# routes/server_routes.py
server_bp = Blueprint("server", __name__, url_prefix="/api/server")

def register_server_routes(hugo_manager):
    @server_bp.route("/status")
    def server_status():
        status = hugo_manager.get_status()
        return jsonify(status)
    return server_bp

# app.py
app.register_blueprint(register_server_routes(hugo_manager))
```

### 测试更新

4 个测试文件适配 `settings_state` 模式：
- `tests/test_settings_api.py` — fixture 改用 `settings_state[key][0]`
- `tests/test_publish_api.py` — `post_service` 替换改用 `settings_state`
- `tests/test_publish_integration.py` — 同上
- `tests/test_spa_routes.py` — `REACT_INDEX` 改用 `app.config`

## 不变的部分

- 所有 API 路径和行为完全不变
- 前端代码无改动
- 服务层（`services/`）无改动
- 现有 `routes/ai_routes.py` 无改动

## 验证

- [x] 96/96 测试全部通过
- [x] `app.py` 247 行（目标 <250 行）
- [x] pre-commit hooks（flake8, black, isort）全部通过
- [x] 所有 API 端点路径不变