### PR TITLE
ci: add frontend build check to catch stale artifacts

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,35 @@
+name: Frontend Build
+
+on:
+  push:
+    branches: [master, main, develop]
+    paths:
+      - 'frontend/**'
+  pull_request:
+    branches: [master, main, develop]
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build (tsc + vite)
+        working-directory: frontend
+        run: pnpm run build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "2.1.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.0",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -31,10 +31,7 @@ export default function Editor() {
   const [content, setContent] = useState('');
   const [originalContent, setOriginalContent] = useState('');
   const [preview, setPreview] = useState('');
-  const hasChanges = useMemo(
-    () => content !== originalContent || JSON.stringify(frontmatter) !== JSON.stringify(originalFrontmatter),
-    [content, originalContent, frontmatter, originalFrontmatter],
-  );
+
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -45,6 +42,10 @@ export default function Editor() {
   const [backlinks, setBacklinks] = useState<Backlink[]>([]);
   const [frontmatter, setFrontmatter] = useState<Frontmatter>({});
   const [originalFrontmatter, setOriginalFrontmatter] = useState<Frontmatter>({});
+  const hasChanges = useMemo(
+    () => content !== originalContent || JSON.stringify(frontmatter) !== JSON.stringify(originalFrontmatter),
+    [content, originalContent, frontmatter, originalFrontmatter],
+  );
   const [fmEdit, setFmEdit] = useState<Record<string, string>>({});
   const [fmTagsStr, setFmTagsStr] = useState('');
   const [fmCategoriesStr, setFmCategoriesStr] = useState('');

--- a/run.sh
+++ b/run.sh
@@ -29,8 +29,22 @@ else
     echo "✓ 依赖已安装"
 fi
 
+
 echo ""
-echo "2. 检查 Hugo..."
+echo "2. 构建前端..."
+if [ -d "frontend/node_modules" ]; then
+    (cd frontend && npm run build)
+else
+    (cd frontend && npm install && npm run build)
+fi
+if [ $? -ne 0 ]; then
+    echo "错误: 前端构建失败"
+    exit 1
+fi
+echo "✓ 前端构建完成"
+
+echo ""
+echo "3. 检查 Hugo..."
 if ! command -v hugo &> /dev/null; then
     echo "警告: 未找到 hugo 命令"
     echo "Hugo 服务器控制功能将不可用"


### PR DESCRIPTION
## Summary

Add CI workflow to verify frontend builds successfully when `frontend/**` files change, preventing stale production artifacts from being silently served.

## Changes

### `.github/workflows/frontend.yml` (new)
- Triggered on push/PR to main/develop when `frontend/**` changes
- Runs `pnpm install --frozen-lockfile` + `pnpm run build` (`tsc -b && vite build`)
- If `tsc` type-checking fails, CI fails — prevents the exact scenario from #78

### `run.sh`
- Add frontend build step (step 2) before starting the Flask app
- `git clone` + `bash run.sh` is now a complete bootstrap — no manual `npm run build` needed

### `frontend/package.json`
- Add `engines.node: ">=22"` and `packageManager: "pnpm@9.15.0"` to pin runtime versions

## Acceptance criteria

- [x] `tsc` compilation errors are caught by CI (`pnpm run build` runs `tsc -b && vite build`)
- [x] Frontend build is part of the automated pipeline (`run.sh` builds before serving)

## Notes

- `static/dist/` is gitignored, so diff-based freshness checks are not applicable. The CI gate (build must succeed) catches the described failure mode.
- Uses `pnpm` in CI (matching `pnpm-lock.yaml`) and `npm` in `run.sh` (zero-install local dev).

Closes #78