### PR TITLE
fix: 修复邮件推送中文 URL 匹配失败

### DIFF
--- a/services/email_service.py
+++ b/services/email_service.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import feedparser
 import requests
@@ -52,7 +52,7 @@ def _normalize_url_for_match(raw_url):
     # path-only（以 / 开头）
     if url.startswith("/"):
         path = url.rstrip("/")
-        return ("", _strip_html_suffix(path))
+        return ("", _strip_html_suffix(unquote(path)))
 
     # 无 scheme 的非路径输入：补 https://
     if "://" not in url:
@@ -64,7 +64,7 @@ def _normalize_url_for_match(raw_url):
         netloc = netloc[4:]
 
     path = parsed.path.rstrip("/")
-    return (netloc, _strip_html_suffix(path))
+    return (netloc, _strip_html_suffix(unquote(path)))
 
 
 class EmailService:
@@ -176,8 +176,7 @@ class EmailService:
                 entry_netloc = parsed.netloc.lower()
                 if entry_netloc.startswith("www."):
                     entry_netloc = entry_netloc[4:]
-                entry_path = _strip_html_suffix(parsed.path.rstrip("/"))
-
+                entry_path = _strip_html_suffix(unquote(parsed.path.rstrip("/")))
                 netloc_matches = (target_netloc == "") or (
                     target_netloc == entry_netloc
                 )


### PR DESCRIPTION
## 问题

`/api/email/preview-article` 和 `/api/email/push-article` 输入中文 URL 时返回 400。

## 根因

RSS feed 中的 entry.link 是 percent-encoded 的（如 `%E4%B8%8D%E5%90%8C%E7%9A%84-coding-plan`），而用户输入的是原始中文（如 `不同的-coding-plan`）。`get_post_by_url()` 比较路径时没有做编码归一化，导致永远匹配不上。

## 修复

在 `_normalize_url_for_match()` 和 `get_post_by_url()` 中，对 path 统一做 `urllib.parse.unquote()` 后再比较。

- 用户输入 → unquote → `不同的-coding-plan-要使用不同的-agent`
- RSS entry → unquote → `不同的-coding-plan-要使用不同的-agent`
- 匹配成功

## 测试

129 个测试全部通过。