### PR TITLE
feat: add plugin system proposal

### DIFF
--- a/openspec/changes/add-plugin-system/design.md
+++ b/openspec/changes/add-plugin-system/design.md
@@ -1,0 +1,183 @@
+## Context
+
+hugo-admin is a Python/Flask + React SPA for managing Hugo blogs. It currently handles image uploads by saving files locally to the Hugo content directory. Users want to extend this with external hosting (Cloudflare Images, S3, etc.) and potentially other capabilities, without modifying core code.
+
+Key constraints:
+- Plugin code MUST be closed-source (compiled Go binaries, not Python)
+- Plugins communicate with the Python host over localhost (no network exposure)
+- The system is self-hosted by users; no central authentication
+- First plugin is Cloudflare Images (separate repo `hugo-admin-plugin-cloudflare`)
+
+## Goals / Non-Goals
+
+### Goals
+- Define a stable gRPC protocol that any plugin MUST implement
+- Build a Plugin Manager that handles plugin lifecycle (discover, start, stop, health-check)
+- Provide REST API routes that proxy requests to the correct plugin based on capability
+- Create a frontend UI for plugin management and configuration
+- Implement the first Cloudflare Images plugin as proof-of-concept
+
+### Non-Goals
+- Payment/licensing system (defer to future)
+- Plugin auto-update mechanism (defer)
+- Sandboxed execution (plugins are trusted binaries; security is the admin's responsibility)
+- Multiple concurrent Hugo instances per plugin
+
+## Decisions
+
+### Decision 1: gRPC over HTTP
+
+**Choice**: gRPC with protobuf-defined service contracts.
+
+**Why**:
+- Strong typing — both Go and Python get auto-generated client/server stubs from `.proto`
+- Binary protocol — efficient for image upload (streaming support)
+- Code generation eliminates serialization bugs between Python host and Go plugin
+- Future-proof — adding new capabilities means adding new service definitions, not inventing new JSON schemas
+
+**Alternatives**:
+- HTTP JSON: simpler, but no code generation, manual schema negotiation, harder to evolve
+- stdin/stdout pipe: not bidirectional, poor for streaming, single-connection bottleneck
+
+### Decision 2: Plugin as a subprocess with gRPC server
+
+**Choice**: Each plugin runs as an independent OS process, listening on a dynamic localhost port.
+
+**Why**:
+- Process isolation — a crashing plugin does not crash hugo-admin
+- Language agnostic — any language with gRPC support can be a plugin (Go chosen for IP protection)
+- Dynamic port allocation avoids conflicts when multiple plugins run simultaneously
+- Plugin Manager assigns ports at startup; plugin reports readiness via gRPC handshake
+
+**Plugin startup flow**:
+1. Plugin Manager reads `plugin.toml` from plugin directory
+2. Spawns plugin binary with `--port <assigned_port>` argument
+3. Waits for gRPC `HealthCheck` to succeed (with timeout)
+4. Calls `PluginService.Info()` to discover capabilities
+5. Registers Flask proxy routes for discovered capabilities
+
+### Decision 3: Plugin manifest format (plugin.toml)
+
+```toml
+[plugin]
+name = "cloudflare-images"
+version = "1.0.0"
+author = "svtter"
+description = "Upload images to Cloudflare Images"
+entry = "./bin/cloudflare-images-plugin"
+
+[capabilities]
+image_upload = true
+
+[config_schema]
+# JSON Schema describing user-configurable settings
+schema = '''
+{
+  "type": "object",
+  "properties": {
+    "api_token": { "type": "string", "label": "API Token" },
+    "account_id": { "type": "string", "label": "Account ID" }
+  },
+  "required": ["api_token", "account_id"]
+}
+'''
+```
+
+**Why TOML**: Human-readable, standard in Go ecosystem (BurntSushi/toml), supports nested structures.
+
+### Decision 4: Capability-based routing
+
+Each plugin declares capabilities in its manifest. The Plugin Manager creates Flask routes scoped to the plugin:
+
+| Capability | Route pattern | gRPC service |
+|---|---|---|
+| `image_upload` | `POST /api/plugins/<name>/image/upload` | `ImageUploader.Upload` |
+| `image_upload` | `DELETE /api/plugins/<name>/image/<id>` | `ImageUploader.Delete` |
+
+When multiple plugins provide the same capability, the user selects the active one in Settings.
+
+### Decision 5: Plugin storage layout
+
+```
+~/.hugo-admin/
+  plugins/
+    cloudflare-images/
+      plugin.toml
+      bin/
+        cloudflare-images-plugin   # compiled Go binary
+    another-plugin/
+      plugin.toml
+      bin/
+        another-plugin
+  plugin-config.json               # persisted user config per plugin
+```
+
+**Why `~/.hugo-admin/`**: Separate from the project directory — plugins are user-level, not per-project. Same plugins work across multiple hugo-admin instances.
+
+### Decision 6: gRPC Protocol Definition
+
+```protobuf
+syntax = "proto3";
+package hugo_admin.plugin;
+
+// Core service every plugin MUST implement
+service PluginService {
+  rpc Info(Empty) returns (PluginInfo);
+  rpc HealthCheck(Empty) returns (HealthResponse);
+  rpc GetConfigSchema(Empty) returns (ConfigSchemaResponse);
+  rpc SetConfig(SetConfigRequest) returns (SetConfigResponse);
+}
+
+// Optional capability: Image Upload
+service ImageUploader {
+  rpc Upload(ImageUploadRequest) returns (ImageUploadResponse);
+  rpc Delete(ImageDeleteRequest) returns (ImageDeleteResponse);
+}
+```
+
+### Decision 7: Market manifest
+
+A simple JSON file hosted at a configurable URL:
+
+```json
+{
+  "version": 1,
+  "plugins": [
+    {
+      "name": "cloudflare-images",
+      "version": "1.0.0",
+      "description": "Upload images to Cloudflare Images",
+      "author": "svtter",
+      "download_url": "https://releases.example.com/plugins/cloudflare-images/v1.0.0.tar.gz",
+      "sha256": "abc123...",
+      "capabilities": ["image_upload"],
+      "config_schema": { ... }
+    }
+  ]
+}
+```
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Plugin process hangs on shutdown | Plugin Manager sends SIGTERM, waits 5s, then SIGKILL |
+| Plugin binary incompatible with host OS/arch | Manifest includes `platform` and `arch` fields; Plugin Manager checks before install |
+| gRPC port conflict | Dynamic port assignment via OS; plugin accepts `--port` flag |
+| Malicious plugin | Plugins run as the same user as hugo-admin — admin trusts installed plugins. Future: code signing |
+| Plugin breaks on hugo-admin upgrade | Protocol versioning in `PluginInfo`; Manager checks compatibility |
+
+## Migration Plan
+
+1. Add `grpcio` / `grpcio-tools` to `pyproject.toml` dependencies
+2. Add `proto/` directory with `.proto` files
+3. Add plugin infrastructure (`plugin_manager.py`, `plugin_routes.py`)
+4. Add frontend plugin management page
+5. Existing image upload flow remains unchanged — plugin upload is an additional option, not a replacement
+6. No breaking changes to existing APIs
+
+## Open Questions
+
+- Should the plugin market URL be configurable in Settings, or hardcoded?
+- Should we support plugin hot-reload (install without restart), or require hugo-admin restart?
+- For the Cloudflare plugin repo — should it be public (marketing) or private?

--- a/openspec/changes/add-plugin-system/design.md
+++ b/openspec/changes/add-plugin-system/design.md
@@ -65,12 +65,19 @@ version = "1.0.0"
 author = "svtter"
 description = "Upload images to Cloudflare Images"
 entry = "./bin/cloudflare-images-plugin"
+protocol_version = "1"
+priority = 100
+
+[build]
+platform = "linux"       # target platform: linux, darwin, windows
+arch = "amd64"           # target architecture: amd64, arm64
 
 [capabilities]
 image_upload = true
 
 [config_schema]
 # JSON Schema describing user-configurable settings
+# Recursion depth is limited to 5 levels; no $ref/allOf/oneOf allowed
 schema = '''
 {
   "type": "object",
@@ -128,20 +135,35 @@ service PluginService {
   rpc SetConfig(SetConfigRequest) returns (SetConfigResponse);
 }
 
-// Optional capability: Image Upload
+// Optional capability: Image Upload (client-streaming for large files)
 service ImageUploader {
-  rpc Upload(ImageUploadRequest) returns (ImageUploadResponse);
+  rpc Upload(stream ImageUploadChunk) returns (ImageUploadResponse);
   rpc Delete(ImageDeleteRequest) returns (ImageDeleteResponse);
+}
+
+message ImageUploadChunk {
+  bytes data = 1;         // file content chunk (64 KiB)
+  string filename = 2;    // original filename
+  string mime_type = 3;   // e.g. "image/png"
+  string article_path = 4;// target article path for context
+  bool is_last = 5;       // true on the final chunk
 }
 ```
 
 ### Decision 7: Market manifest
 
-A simple JSON file hosted at a configurable URL:
+A JSON file hosted at a hardcoded HTTPS URL. Third-party distribution is out of scope for v1 — the market is curated and operated by the hugo-admin maintainer.
+
+**Security constraints**:
+- Market URL MUST use HTTPS; SSRF prevention blocks non-HTTPS and private/internal IP ranges (RFC 1918, link-local)
+- Each plugin package MUST be accompanied by a Minisign signature (`.tar.gz.minisig`)
+- On install: verify SHA256 digest of the downloaded archive, then verify the Minisign signature against the embedded public key
+- Market manifest cache: 5-minute TTL, stored alongside its SHA256; stale cache rejected if digest mismatches
 
 ```json
 {
   "version": 1,
+  "public_key": "RW... (minisign public key)",
   "plugins": [
     {
       "name": "cloudflare-images",
@@ -149,7 +171,10 @@ A simple JSON file hosted at a configurable URL:
       "description": "Upload images to Cloudflare Images",
       "author": "svtter",
       "download_url": "https://releases.example.com/plugins/cloudflare-images/v1.0.0.tar.gz",
+      "signature_url": "https://releases.example.com/plugins/cloudflare-images/v1.0.0.tar.gz.minisig",
       "sha256": "abc123...",
+      "platform": "linux",
+      "arch": "amd64",
       "capabilities": ["image_upload"],
       "config_schema": { ... }
     }
@@ -166,18 +191,55 @@ A simple JSON file hosted at a configurable URL:
 | gRPC port conflict | Dynamic port assignment via OS; plugin accepts `--port` flag |
 | Malicious plugin | Plugins run as the same user as hugo-admin — admin trusts installed plugins. Future: code signing |
 | Plugin breaks on hugo-admin upgrade | Protocol versioning in `PluginInfo`; Manager checks compatibility |
+| Plugin config credential leak | Fernet symmetric encryption; key derived from a machine-specific secret stored in `~/.hugo-admin/.secret_key` |
+| Path traversal in plugin entry | Entry resolved to absolute path and validated to be within the plugin directory; symlinks dereferenced |
+| Man-in-the-middle on plugin download | Minisign signature verification on every install; SHA256 digest double-check |
+| gRPC 4 MiB message size limit | `ImageUploader.Upload` uses client-streaming RPC; Flask reads file in 64 KiB chunks, streams to plugin. Accepted constraint: max upload 16 MB (Flask `MAX_CONTENT_LENGTH`) |
+
+### Decision 8: Plugin config encryption
+
+**Choice**: Fernet symmetric encryption for sensitive plugin configuration values.
+
+**Why**:
+- API tokens, account IDs, and other credentials MUST NOT be stored in plaintext
+- Fernet (via `cryptography` package) provides authenticated encryption — tampering is detectable
+- Key derivation: on first use, generate a random 256-bit key and store it in `~/.hugo-admin/.secret_key` (file permissions `0600`)
+- Non-sensitive config values (e.g., preferred theme) remain plaintext for readability
+
+**Implementation**: The Plugin Manager encrypts values marked `"sensitive": true` in the plugin's `config_schema` before writing to `plugin-config.json`. On read, encrypted values are transparently decrypted before being forwarded to the plugin via gRPC `SetConfig`.
+
+### Decision 9: Plugin binary path validation
+
+**Choice**: Resolve and sandbox the `entry` path before passing to `subprocess.Popen`.
+
+**Implementation**:
+1. Join the plugin directory absolute path with the relative `entry` from `plugin.toml`
+2. Call `os.path.realpath()` to dereference any symlinks
+3. Verify the resolved path starts with the plugin directory (no `../` traversal)
+4. Verify the file exists and has executable bit set
+5. Only then pass the resolved absolute path to `subprocess.Popen`
+
+### Decision 10: Plugin package signature verification
+
+**Choice**: Minisign for plugin package integrity and authenticity.
+
+**Why**:
+- Minisign is lightweight, well-audited, and widely used in the Go ecosystem
+- The market manifest embeds a trusted public key; each plugin archive ships with a `.tar.gz.minisign` signature file
+- On install: download archive + signature, verify SHA256, then verify Minisign signature against the trusted public key
+- A compromised mirror cannot serve malicious plugins without the signer's private key
 
 ## Migration Plan
 
-1. Add `grpcio` / `grpcio-tools` to `pyproject.toml` dependencies
+1. Add `grpcio`, `grpcio-tools`, `cryptography`, `minisign` to `pyproject.toml` dependencies
 2. Add `proto/` directory with `.proto` files
 3. Add plugin infrastructure (`plugin_manager.py`, `plugin_routes.py`)
 4. Add frontend plugin management page
-5. Existing image upload flow remains unchanged — plugin upload is an additional option, not a replacement
+5. Existing image upload flow remains unchanged — plugin upload is an additional option (parallel, not replacement)
 6. No breaking changes to existing APIs
 
-## Open Questions
+## Resolved Questions
 
-- Should the plugin market URL be configurable in Settings, or hardcoded?
-- Should we support plugin hot-reload (install without restart), or require hugo-admin restart?
-- For the Cloudflare plugin repo — should it be public (marketing) or private?
+- **Market URL**: Hardcoded to `https://plugins.hugo-admin.dev/manifest.json` (HTTPS-only, no user configuration in v1)
+- **Hot-reload**: Not supported in v1. Installing a new plugin requires hugo-admin restart. This avoids runtime complexity (route registration/de-registration, in-process gRPC channel teardown)
+- **Cloudflare plugin repo**: Public repository (marketing value); the Go source is readable but the distributed artifact is the compiled binary from CI releases

--- a/openspec/changes/add-plugin-system/proposal.md
+++ b/openspec/changes/add-plugin-system/proposal.md
@@ -1,0 +1,24 @@
+# Change: Add Plugin System with gRPC-based Extension Architecture
+
+## Why
+
+hugo-admin needs a plugin mechanism to support private, closed-source extensions (e.g., Cloudflare Images hosting) without modifying the core codebase. Plugins are distributed as pre-compiled Go binaries, communicating with the Python host via gRPC. This protects plugin source code while enabling a marketplace-driven ecosystem.
+
+## What Changes
+
+- **Plugin Protocol**: Define a gRPC service contract (`PluginService`) that all plugins MUST implement. Includes metadata discovery, health checks, and typed capability interfaces (e.g., `ImageUploader`).
+- **Plugin Manager**: A Python service (`services/plugin_manager.py`) that discovers installed plugins, starts/stops plugin processes, manages gRPC connections, and registers proxy API routes into Flask.
+- **Plugin Registry API**: REST endpoints for listing installed plugins, configuring plugin settings, and managing plugin lifecycle (install/enable/disable/uninstall).
+- **Plugin Market API**: REST endpoint serving a curated plugin catalog from a remote manifest JSON, supporting browsing and download.
+- **Frontend Plugin UI**: New "Plugins" page in Settings for browsing the market, managing installed plugins, and per-plugin configuration forms (auto-generated from plugin-declared config schema).
+- **Cloudflare Images Plugin**: First reference plugin (separate Go repo `hugo-admin-plugin-cloudflare`) implementing `ImageUploader` capability. Users provide API Token + Account ID; plugin uploads images to Cloudflare and returns public URLs.
+
+## Impact
+
+- Affected specs: `ai-tools-integration` (image upload flow gains plugin-aware routing), new spec `plugin-system`
+- Affected code:
+  - New: `services/plugin_manager.py`, `services/plugin_service.py`, `routes/plugin_routes.py`, `proto/plugin.proto`
+  - New: `frontend/src/pages/Plugins.tsx`, `frontend/src/components/PluginCard.tsx`
+  - Modified: `app.py` (register plugin routes, init plugin manager), `services/registry.py` (expose plugin manager)
+  - External: new Go repo `hugo-admin-plugin-cloudflare` (independent repository)
+- New dependencies: `grpcio`, `grpcio-tools` (Python); `google.golang.org/grpc` (Go plugins)

--- a/openspec/changes/add-plugin-system/proposal.md
+++ b/openspec/changes/add-plugin-system/proposal.md
@@ -19,6 +19,7 @@ hugo-admin needs a plugin mechanism to support private, closed-source extensions
 - Affected code:
   - New: `services/plugin_manager.py`, `services/plugin_service.py`, `routes/plugin_routes.py`, `proto/plugin.proto`
   - New: `frontend/src/pages/Plugins.tsx`, `frontend/src/components/PluginCard.tsx`
+  - New: `tests/test_plugin_manager.py`, `tests/test_plugin_routes.py`, `tests/test_plugin_integration.py`
   - Modified: `app.py` (register plugin routes, init plugin manager), `services/registry.py` (expose plugin manager)
   - External: new Go repo `hugo-admin-plugin-cloudflare` (independent repository)
-- New dependencies: `grpcio`, `grpcio-tools` (Python); `google.golang.org/grpc` (Go plugins)
+- New dependencies: `grpcio`, `grpcio-tools`, `cryptography`, `minisign` (Python); `google.golang.org/grpc` (Go plugins)

--- a/openspec/changes/add-plugin-system/specs/plugin-system/spec.md
+++ b/openspec/changes/add-plugin-system/specs/plugin-system/spec.md
@@ -1,10 +1,10 @@
 ## ADDED Requirements
 
-### Requirement: Plugin Protocol Definition
 The system SHALL define a gRPC-based plugin protocol (`plugin.proto`) that specifies:
 - A `PluginService` with `Info`, `HealthCheck`, `GetConfigSchema`, and `SetConfig` RPCs
-- An `ImageUploader` service with `Upload` and `Delete` RPCs
-- Standard message types for plugin metadata, image data, and configuration
+- An `ImageUploader` service with client-streaming `Upload` and unary `Delete` RPCs
+- Standard message types including `ImageUploadChunk` (64 KiB chunks) for streaming large files
+- Accepted size constraint: max upload 16 MB (Flask `MAX_CONTENT_LENGTH`), streamed via gRPC client-streaming to avoid double-buffering
 
 #### Scenario: Plugin binary starts and responds to handshake
 - **WHEN** Plugin Manager spawns a plugin binary with `--port <port>`
@@ -27,6 +27,11 @@ The system SHALL require each plugin to provide a `plugin.toml` manifest contain
 - **THEN** it SHALL parse each subdirectory's `plugin.toml`
 - **AND** skip directories that do not contain a valid `plugin.toml`
 
+#### Scenario: Invalid plugin.toml is rejected
+- **WHEN** a `plugin.toml` is missing required fields (`[plugin]` section with `name`, `version`, `entry`) or contains malformed TOML
+- **THEN** Plugin Manager SHALL log a warning and skip that directory
+- **AND** NOT attempt to start the plugin
+
 ### Requirement: Plugin Manager Lifecycle
 The system SHALL provide a `PluginManager` service that:
 - Discovers installed plugins from `~/.hugo-admin/plugins/` on startup
@@ -41,7 +46,11 @@ The system SHALL provide a `PluginManager` service that:
 - **THEN** Plugin Manager SHALL start each plugin binary
 - **AND** register Flask API routes for each discovered capability
 - **AND** skip plugins that fail health check, logging a warning
-
+#### Scenario: Disabled plugin has routes unregistered
+- **WHEN** a plugin is disabled via `POST /api/plugins/<name>/disable`
+- **THEN** the system SHALL stop the plugin process
+- **AND** unregister all Flask API routes that were registered for that plugin's capabilities
+- **AND** retain the plugin's configuration for re-enable
 #### Scenario: Plugin process is terminated on shutdown
 - **WHEN** hugo-admin shuts down
 - **THEN** Plugin Manager SHALL send SIGTERM to all running plugin processes
@@ -55,7 +64,7 @@ The system SHALL automatically register Flask API routes for each plugin capabil
 
 #### Scenario: User uploads image via plugin
 - **WHEN** frontend sends `POST /api/plugins/cloudflare-images/image/upload` with a multipart file
-- **THEN** the Flask proxy route SHALL forward the image data via gRPC `ImageUploader.Upload` to the plugin
+- **THEN** the Flask proxy route SHALL stream the file data to the plugin via gRPC client-streaming `ImageUploader.Upload`
 - **AND** return the plugin's response (including the hosted image URL) to the frontend
 
 ### Requirement: Plugin REST API

--- a/openspec/changes/add-plugin-system/specs/plugin-system/spec.md
+++ b/openspec/changes/add-plugin-system/specs/plugin-system/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Plugin Protocol Definition
+The system SHALL define a gRPC-based plugin protocol (`plugin.proto`) that specifies:
+- A `PluginService` with `Info`, `HealthCheck`, `GetConfigSchema`, and `SetConfig` RPCs
+- An `ImageUploader` service with `Upload` and `Delete` RPCs
+- Standard message types for plugin metadata, image data, and configuration
+
+#### Scenario: Plugin binary starts and responds to handshake
+- **WHEN** Plugin Manager spawns a plugin binary with `--port <port>`
+- **THEN** the plugin SHALL start a gRPC server on the specified port
+- **AND** respond to `PluginService.HealthCheck` within 10 seconds
+
+#### Scenario: Plugin declares its capabilities
+- **WHEN** Plugin Manager calls `PluginService.Info` on a running plugin
+- **THEN** the plugin SHALL return its name, version, description, and list of supported capabilities (e.g., `image_upload`)
+
+### Requirement: Plugin Manifest Format
+The system SHALL require each plugin to provide a `plugin.toml` manifest containing:
+- Plugin identity (`name`, `version`, `author`, `description`)
+- Binary entry point (`entry` path relative to plugin directory)
+- Declared capabilities (e.g., `image_upload = true`)
+- Configuration schema (JSON Schema describing user-configurable settings)
+
+#### Scenario: Plugin Manager reads manifest
+- **WHEN** Plugin Manager scans `~/.hugo-admin/plugins/` directory
+- **THEN** it SHALL parse each subdirectory's `plugin.toml`
+- **AND** skip directories that do not contain a valid `plugin.toml`
+
+### Requirement: Plugin Manager Lifecycle
+The system SHALL provide a `PluginManager` service that:
+- Discovers installed plugins from `~/.hugo-admin/plugins/` on startup
+- Assigns a dynamic localhost port to each plugin
+- Starts plugin binaries as subprocess processes
+- Performs gRPC handshake (HealthCheck + Info) within a configurable timeout
+- Stops plugin processes gracefully (SIGTERM → wait → SIGKILL) on shutdown
+- Persists per-plugin user configuration in `~/.hugo-admin/plugin-config.json`
+
+#### Scenario: All healthy plugins start on hugo-admin boot
+- **WHEN** hugo-admin starts and `~/.hugo-admin/plugins/` contains valid plugin directories
+- **THEN** Plugin Manager SHALL start each plugin binary
+- **AND** register Flask API routes for each discovered capability
+- **AND** skip plugins that fail health check, logging a warning
+
+#### Scenario: Plugin process is terminated on shutdown
+- **WHEN** hugo-admin shuts down
+- **THEN** Plugin Manager SHALL send SIGTERM to all running plugin processes
+- **AND** wait up to 5 seconds
+- **AND** send SIGKILL to any remaining processes
+
+### Requirement: Plugin Capability Routing
+The system SHALL automatically register Flask API routes for each plugin capability:
+- `image_upload` capability → `POST /api/plugins/<name>/image/upload` and `DELETE /api/plugins/<name>/image/<image_id>`
+- Routes SHALL proxy HTTP requests to the corresponding gRPC service on the plugin process
+
+#### Scenario: User uploads image via plugin
+- **WHEN** frontend sends `POST /api/plugins/cloudflare-images/image/upload` with a multipart file
+- **THEN** the Flask proxy route SHALL forward the image data via gRPC `ImageUploader.Upload` to the plugin
+- **AND** return the plugin's response (including the hosted image URL) to the frontend
+
+### Requirement: Plugin REST API
+The system SHALL provide REST endpoints for plugin management:
+- `GET /api/plugins` — list installed plugins with status, capabilities, and configuration state
+- `GET /api/plugins/<name>/config-schema` — return the plugin's configuration schema
+- `PUT /api/plugins/<name>/config` — update plugin configuration
+- `POST /api/plugins/<name>/enable` — enable a plugin
+- `POST /api/plugins/<name>/disable` — disable a plugin (stop the process, keep configuration)
+
+#### Scenario: User configures Cloudflare plugin
+- **WHEN** user sends `PUT /api/plugins/cloudflare-images/config` with `{"api_token": "xxx", "account_id": "yyy"}`
+- **THEN** the system SHALL persist the configuration
+- **AND** forward it to the running plugin via gRPC `SetConfig`
+
+### Requirement: Plugin Market API
+The system SHALL provide an endpoint to browse available plugins:
+- `GET /api/plugins/market` — fetch the remote plugin manifest and return the catalog
+
+#### Scenario: User browses plugin market
+- **WHEN** frontend requests `GET /api/plugins/market`
+- **THEN** the system SHALL fetch the remote manifest JSON from the configured market URL
+- **AND** return the list of available plugins with name, version, description, and capabilities
+
+### Requirement: Frontend Plugin Management Page
+The system SHALL provide a "Plugins" section in the Settings page that includes:
+- A "Market" tab showing available plugins from the remote catalog
+- An "Installed" tab showing installed plugins with enable/disable toggles
+- Per-plugin configuration forms auto-generated from the plugin's config schema
+- Status indicators (running/stopped/error) for each installed plugin
+
+#### Scenario: User installs a plugin from market
+- **WHEN** user clicks "Install" on a market plugin card
+- **THEN** the system SHALL download the plugin package from the market URL
+- **AND** extract it to `~/.hugo-admin/plugins/<name>/`
+- **AND** start the plugin if it passes health check
+
+#### Scenario: User views installed plugins
+- **WHEN** user navigates to the "Installed" tab
+- **THEN** the system SHALL display each installed plugin with its name, version, status, and a "Configure" button
+
+### Requirement: Cloudflare Images Plugin
+The Cloudflare Images plugin (separate Go repo) SHALL implement:
+- The `PluginService` gRPC interface (Info, HealthCheck, GetConfigSchema, SetConfig)
+- The `ImageUploader` gRPC interface (Upload, Delete)
+- Upload images to Cloudflare Images via the Cloudflare API using user-provided API Token and Account ID
+- Return the public CDN URL of the uploaded image
+
+#### Scenario: Plugin uploads image to Cloudflare
+- **WHEN** Plugin Manager proxies an image upload request to the Cloudflare plugin
+- **THEN** the plugin SHALL call the Cloudflare Images API with the user's configured API Token
+- **AND** return `{ success: true, url: "https://...cloudflare.com/..." }`
+
+#### Scenario: Plugin requires valid configuration
+- **WHEN** a user tries to upload without configuring API Token and Account ID
+- **THEN** the plugin SHALL return `{ success: false, message: "API Token and Account ID are required" }`

--- a/openspec/changes/add-plugin-system/tasks.md
+++ b/openspec/changes/add-plugin-system/tasks.md
@@ -1,0 +1,46 @@
+## 1. Protocol & SDK
+
+- [ ] 1.1 Define `proto/plugin.proto` with `PluginService`, `ImageUploader` message types
+- [ ] 1.2 Generate Python gRPC stubs (`grpcio-tools`)
+- [ ] 1.3 Create Go gRPC SDK skeleton (to be used by `hugo-admin-plugin-cloudflare` repo)
+- [ ] 1.4 Define `plugin.toml` manifest schema and write a TOML parser in Python
+
+## 2. Plugin Manager (Python)
+
+- [ ] 2.1 Create `services/plugin_manager.py`: plugin discovery from `~/.hugo-admin/plugins/`
+- [ ] 2.2 Implement subprocess lifecycle: start with dynamic port, health-check handshake, graceful shutdown
+- [ ] 2.3 Implement gRPC client wrapper: connect to plugin, call Info/HealthCheck/SetConfig
+- [ ] 2.4 Implement capability route registration: proxy Flask routes to gRPC services
+- [ ] 2.5 Implement plugin configuration persistence in `~/.hugo-admin/plugin-config.json`
+
+## 3. REST API
+
+- [ ] 3.1 Create `routes/plugin_routes.py` with endpoints: list, config-schema, config, enable, disable
+- [ ] 3.2 Add market endpoint `GET /api/plugins/market` (fetch remote manifest, cache result)
+- [ ] 3.3 Register plugin blueprint in `app.py`
+- [ ] 3.4 Expose `plugin_manager` through `ServiceRegistry`
+
+## 4. Frontend
+
+- [ ] 4.1 Create `frontend/src/pages/Plugins.tsx` with Market / Installed tabs
+- [ ] 4.2 Create `frontend/src/components/PluginCard.tsx` for plugin display (market & installed)
+- [ ] 4.3 Auto-generate config forms from plugin config schema
+- [ ] 4.4 Integrate Plugins section into Settings navigation (or standalone page)
+- [ ] 4.5 Wire image upload in Editor to use active image plugin when available
+
+## 5. Cloudflare Images Plugin (Go, separate repo)
+
+- [ ] 5.1 Create `hugo-admin-plugin-cloudflare` Go repo
+- [ ] 5.2 Implement `PluginService` gRPC server (Info, HealthCheck, GetConfigSchema, SetConfig)
+- [ ] 5.3 Implement `ImageUploader` gRPC server (Upload, Delete via Cloudflare Images API)
+- [ ] 5.4 Write `plugin.toml` manifest
+- [ ] 5.5 Build script: cross-compile for linux-amd64, linux-arm64, darwin-amd64, darwin-arm64
+- [ ] 5.6 Package as `.tar.gz` with binary + manifest
+
+## 6. Integration & Testing
+
+- [ ] 6.1 Add `grpcio`, `grpcio-tools` to `pyproject.toml`
+- [ ] 6.2 Write unit tests for `plugin_manager.py` (subprocess mock, gRPC mock)
+- [ ] 6.3 Write unit tests for `plugin_routes.py` (API endpoints)
+- [ ] 6.4 Write integration test: start mock plugin, verify proxy route works end-to-end
+- [ ] 6.5 Verify existing image upload still works (no regression)


### PR DESCRIPTION
## Summary

Introduce a plugin mechanism for hugo-admin that allows closed-source Go binary plugins to extend the system via gRPC communication.

## Architecture

```
hugo-admin (Python/Flask)
  └─ Plugin Manager
       ├─ gRPC health-check + Info handshake
       ├─ Dynamic port allocation per plugin
       └─ Flask proxy routes per capability
            └─ Plugin binary (Go, compiled)
```

**Key decisions:**
- **gRPC protocol** — strong typing, auto-generated stubs for Go/Python
- **Subprocess model** — each plugin runs as an independent process on a dynamic localhost port
- **`plugin.toml` manifest** — declares name, version, capabilities, config schema
- **`~/.hugo-admin/plugins/`** — user-level plugin storage, cross-project
- **Remote JSON manifest** — lightweight plugin market (no SaaS initially)

## First Plugin: Cloudflare Images

Separate closed-source Go repo (`hugo-admin-plugin-cloudflare`). Users provide Cloudflare API Token + Account ID; plugin uploads images and returns CDN URLs.

## Files Added

| File | Description |
|------|-------------|
| `openspec/changes/add-plugin-system/proposal.md` | Why, what, impact |
| `openspec/changes/add-plugin-system/design.md` | Architecture decisions, trade-offs |
| `openspec/changes/add-plugin-system/tasks.md` | Implementation checklist (6 phases) |
| `openspec/changes/add-plugin-system/specs/plugin-system/spec.md` | Requirements with scenarios |

## Impact

- New dependencies: `grpcio`, `grpcio-tools` (Python)
- New services: `plugin_manager.py`, `plugin_routes.py`
- New frontend: Plugins management page
- No breaking changes to existing APIs