### PR TITLE
docs: add Docker installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,36 +31,40 @@
 - **Database**: SQLite (for caching)
 
 ## Installation
-
-### Requirements
-
+### Docker (Recommended)
+Pull the image from GHCR and run with Docker Compose:
+```bash
+# Clone the repository
+git clone https://github.com/Svtter/hugo-admin.git
+cd hugo-admin
+# Start the service
+docker compose up -d
+```
+Open your browser and navigate to `http://127.0.0.1:5050`.
+See [docker-compose.yml](docker-compose.yml) for volume mounts and environment variables. Adjust the volume paths to match your Hugo site layout.
+### Manual Setup
+#### Requirements
 - Python 3.9+
 - Hugo (installed and in PATH)
-
-### Steps
-
+#### Steps
 1. Clone the repository:
 ```bash
 git clone https://github.com/Svtter/hugo-admin.git
 cd hugo-admin
 ```
-
 2. Install dependencies:
 ```bash
-pip install -r requirements.txt
+pip install .
 ```
-
 3. Configure the application:
 ```bash
 cp config.py config_local.py
 # Edit config_local.py to set your Hugo root directory
 ```
-
 4. Run the application:
 ```bash
 python app.py
 ```
-
 5. Open your browser and navigate to `http://127.0.0.1:5000`
 
 ## Configuration
@@ -167,10 +171,10 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 - [x] SQLite caching system
 - [x] Test suite with CI/CD
 - [x] Image upload and management
+- [x] Docker support
 - [ ] Git operations interface
 - [ ] Batch operations
 - [ ] Multi-user support
-- [ ] Docker support
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cp config.py config_local.py
 ```bash
 python app.py
 ```
-5. Open your browser and navigate to `http://127.0.0.1:5000`
+5. Open your browser and navigate to `http://127.0.0.1:5050`
 
 ## Configuration
 
@@ -130,18 +130,14 @@ pytest --cov=. --cov-report=html
 hugo-admin/
 ├── app.py                 # Flask application
 ├── config.py              # Configuration
-├── requirements.txt       # Dependencies
-├── requirements-dev.txt   # Dev dependencies
+├── pyproject.toml         # Dependencies and project metadata
+├── Dockerfile             # Docker image build
+├── docker-compose.yml     # Docker Compose configuration
 ├── pytest.ini             # Pytest configuration
 ├── services/              # Business logic
-│   ├── hugo_service.py    # Hugo server management
-│   ├── post_service.py    # Post operations
-│   └── cache_service.py   # Caching layer
-├── models/                # Database models
-│   └── database.py        # SQLite operations
-├── templates/             # Jinja2 templates
-├── static/                # CSS, JS, images
-└── tests/                 # Test suite
+├── routes/                # Flask Blueprints (API routes)
+├── frontend/              # React + Vite SPA
+├── tests/                 # Test suite
 ```
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,7 +65,7 @@ cp config.py config_local.py
 ```bash
 python app.py
 ```
-5. 在浏览器中打开 `http://127.0.0.1:5000`
+5. 在浏览器中打开 `http://127.0.0.1:5050`
 
 ## 配置
 
@@ -130,18 +130,14 @@ pytest --cov=. --cov-report=html
 hugo-admin/
 ├── app.py                 # Flask 应用
 ├── config.py              # 配置文件
-├── requirements.txt       # 依赖
-├── requirements-dev.txt   # 开发依赖
+├── pyproject.toml         # 依赖和项目元数据
+├── Dockerfile             # Docker 镜像构建
+├── docker-compose.yml     # Docker Compose 配置
 ├── pytest.ini             # Pytest 配置
 ├── services/              # 业务逻辑层
-│   ├── hugo_service.py    # Hugo 服务器管理
-│   ├── post_service.py    # 文章操作
-│   └── cache_service.py   # 缓存层
-├── models/                # 数据库模型
-│   └── database.py        # SQLite 操作
-├── templates/             # Jinja2 模板
-├── static/                # CSS、JS、图片
-└── tests/                 # 测试套件
+├── routes/                # Flask 蓝图（API 路由）
+├── frontend/              # React + Vite SPA
+├── tests/                 # 测试套件
 ```
 
 ## 贡献

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,36 +31,40 @@
 - **数据库**: SQLite (用于缓存)
 
 ## 安装
-
-### 环境要求
-
+### Docker（推荐）
+从 GHCR 拉取镜像并使用 Docker Compose 启动：
+```bash
+# 克隆仓库
+git clone https://github.com/Svtter/hugo-admin.git
+cd hugo-admin
+# 启动服务
+docker compose up -d
+```
+在浏览器中打开 `http://127.0.0.1:5050`。
+卷挂载和环境变量请参考 [docker-compose.yml](docker-compose.yml)，根据实际 Hugo 站点目录结构调整挂载路径。
+### 手动安装
+#### 环境要求
 - Python 3.9+
 - Hugo (已安装并在 PATH 中)
-
-### 安装步骤
-
+#### 安装步骤
 1. 克隆仓库:
 ```bash
 git clone https://github.com/Svtter/hugo-admin.git
 cd hugo-admin
 ```
-
 2. 安装依赖:
 ```bash
-pip install -r requirements.txt
+pip install .
 ```
-
 3. 配置应用:
 ```bash
 cp config.py config_local.py
 # 编辑 config_local.py 设置你的 Hugo 根目录
 ```
-
 4. 运行应用:
 ```bash
 python app.py
 ```
-
 5. 在浏览器中打开 `http://127.0.0.1:5000`
 
 ## 配置
@@ -167,10 +171,10 @@ hugo-admin/
 - [x] SQLite 缓存系统
 - [x] 测试套件与 CI/CD
 - [x] 图片上传和管理
+- [x] Docker 支持
 - [ ] Git 操作界面
 - [ ] 批量操作
 - [ ] 多用户支持
-- [ ] Docker 支持
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

- Add **Docker (Recommended)** installation section with `docker compose up -d` command to both English and Chinese READMEs
- Reorganize manual setup under a **Manual Setup** subsection
- Fix `pip install -r requirements.txt` to `pip install .` (project uses pyproject.toml)
- Tick **Docker support** in the roadmap