### PR TITLE
fix: Docker 部署修复

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -68,3 +68,6 @@ specs/
 Dockerfile
 docker-compose.yml
 .dockerignore
+
+# Runtime data (mounted as volume, not copied)
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # Hugo Admin Dockerfile
-# 多阶段构建，用于运行 Hugo Admin 管理界面
 
 FROM python:3.11-slim
 
@@ -37,12 +36,11 @@ RUN pip install --no-cache-dir .
 RUN mkdir -p /app/content /app/public /app/static /app/templates
 
 # 暴露端口
-EXPOSE 5050
-EXPOSE 1313
+EXPOSE 5050 1313
 
 # 健康检查
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:5050/api/server/status || exit 1
 
-# 运行应用
-CMD ["python", "app.py"]
+# 清理 Docker 挂载可能自动创建的 config.toml 目录（Hugo 会误读为配置文件）
+CMD ["sh", "-c", "rm -rf /app/config.toml && python app.py"]

--- a/config.py
+++ b/config.py
@@ -14,12 +14,12 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY") or "dev-secret-key-change-in-production"
     DEBUG = True
 
-    # 项目路径配置
-    BASE_DIR = Path(__file__).parent.parent
+    # 项目路径配置（支持通过环境变量覆盖，便于 Docker 部署）
+    BASE_DIR = Path(os.environ.get("HUGO_ROOT", str(Path(__file__).parent.parent)))
     WEB_ADMIN_DIR = Path(__file__).parent
     HUGO_ROOT = BASE_DIR
-    CONTENT_DIR = BASE_DIR / "content"
-    PUBLIC_DIR = BASE_DIR / "public"
+    CONTENT_DIR = Path(os.environ.get("CONTENT_DIR", str(BASE_DIR / "content")))
+    PUBLIC_DIR = Path(os.environ.get("PUBLIC_DIR", str(BASE_DIR / "public")))
 
     # Hugo 配置
     HUGO_SERVER_HOST = "0.0.0.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,20 @@ services:
       - "5050:5050"  # Hugo Admin 管理界面
       - "1313:1313"  # Hugo 预览服务器
     volumes:
-      # 挂载 Hugo 博客内容目录（需要根据实际情况调整）
-      - ./content:/app/content
-      - ./public:/app/public
-      - ./static:/app/static
-      - ./config.toml:/app/config.toml:ro
-      # 持久化缓存数据库，避免容器重启后缓存丢失
-      - ./data:/app/data
-      # 可选：挂载自定义配置
-      # - ./config_local.py:/app/config_local.py:ro
+      # 挂载 Hugo 博客内容目录（指向实际的 hugo-blog 目录）
+      - ../hugo-blog/content:/app/content
+      - ../hugo-blog/public:/app/public
+      - ../hugo-blog/static:/app/static
+      - ../hugo-blog/config:/app/config:ro
+      # 禁用 Hugo Modules，使用本地主题（覆盖为空文件）
+      - /dev/null:/app/config/_default/module.toml
+      - ../hugo-blog/layouts:/app/layouts
+      - ../hugo-blog/assets:/app/assets
+      - ../hugo-blog/resources:/app/resources
+      # 主题目录：直接挂载实际的 Fried-Rice（Docker 不跟随符号链接）
+      - ../Fried-Rice:/app/themes/stack:ro
+      # 持久化缓存数据库（挂载到 /app 外，避免 Hugo 读取 cache.db）
+      - ./data:/hugo_admin_data
     environment:
       - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
       - FLASK_ENV=${FLASK_ENV:-development}
@@ -28,6 +33,8 @@ services:
       - CONTENT_DIR=/app/content
       - PUBLIC_DIR=/app/public
       - HUGO_SERVER_BASE_URL=${HUGO_SERVER_BASE_URL:-http://localhost:1313}
+      - CACHE_DB_DIR=/hugo_admin_data
+      - HUGO_THEME=stack
     restart: unless-stopped
     networks:
       - hugo-network

--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -5,6 +5,7 @@
 """
 
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -30,7 +31,10 @@ class CacheService:
         self.content_dir = Path(content_dir)
 
         if db_path is None:
-            db_path = Path(__file__).parent.parent / "data" / "cache.db"
+            _data_dir = os.environ.get(
+                "CACHE_DB_DIR", str(Path(__file__).parent.parent / "data")
+            )
+            db_path = Path(_data_dir) / "cache.db"
 
         self.db = Database(str(db_path))
         self._initialized = False

--- a/services/hugo_service.py
+++ b/services/hugo_service.py
@@ -4,6 +4,7 @@ Hugo 服务器管理服务
 负责启动、停止和监控 Hugo 开发服务器
 """
 
+import os
 import subprocess
 import threading
 import time
@@ -64,6 +65,10 @@ class HugoServerManager:
             ]
             if debug:
                 cmd.append("-D")
+            # Docker 部署时禁用了 Hugo Modules，需要显式指定主题
+            theme = os.environ.get("HUGO_THEME", "")
+            if theme:
+                cmd.extend(["--theme", theme])
 
             # 启动进程
             self.process = subprocess.Popen(


### PR DESCRIPTION
## 问题

Docker 部署无法正常工作，主要问题：

1. **Volume 挂载路径错误** — `docker-compose.yml` 挂载的是本地空目录（`./content`），实际博客内容在 `../hugo-blog/`
2. **Hugo 根目录路径错误** — `config.py` 中 `BASE_DIR` 在 Docker 容器内解析为 `/` 而非 `/app`
3. **Hugo 无法启动** — 缺少 `--theme` 参数，且 `config.toml` 被 Docker 自动创建为目录导致报错
4. **Hugo 误读 cache.db** — Hugo 扫描 `/app/data/` 目录时尝试解析 SQLite 数据库文件
5. **符号链接断裂** — 主题 `themes/stack` 是指向 `fried-rice` 的符号链接（大小写不匹配），Docker 不跟随符号链接

## 修复内容

| 文件 | 改动 |
|------|------|
| `docker-compose.yml` | 挂载 `../hugo-blog/` 目录、直接挂载 Fried-Rice 主题、覆盖 module.toml 禁用 Go Modules、数据目录移出 Hugo 根目录、新增 `CACHE_DB_DIR`/`HUGO_THEME` 环境变量 |
| `config.py` | `HUGO_ROOT`/`CONTENT_DIR`/`PUBLIC_DIR` 支持环境变量覆盖（保留本地开发默认值） |
| `services/hugo_service.py` | 读取 `HUGO_THEME` 环境变量，自动添加 `--theme` 参数 |
| `services/cache_service.py` | 读取 `CACHE_DB_DIR` 环境变量，支持将数据库存放到 Hugo 根目录外 |
| `Dockerfile` | CMD 启动前清理 `config.toml` 目录、合并 EXPOSE 端口 |
| `.dockerignore` | 排除 `data/` 目录避免缓存数据库进入镜像 |

## 测试

```bash
docker compose up -d --build
# 等待容器 healthy
curl -X POST http://localhost:5050/api/server/start -H "Content-Type: application/json" -d {}
# 验证
curl http://localhost:5050/api/server/status  # 管理界面
curl http://localhost:1313/                    # 博客预览
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)