### PR TITLE
fix: 地址 PR review 建议 - .env 路径配置 & 安全 rm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Hugo Admin Docker 部署配置
+# 复制此文件为 .env 并根据实际情况修改
+
+# Hugo 博客目录（默认为 ../hugo-blog）
+HUGO_BLOG_DIR=../hugo-blog
+
+# Hugo 主题目录（默认为 ../Fried-Rice）
+HUGO_THEME_DIR=../Fried-Rice
+
+# Flask 密钥（生产环境必须修改）
+SECRET_KEY=dev-secret-key-change-in-production
+
+# Hugo 预览服务器地址
+HUGO_SERVER_BASE_URL=http://localhost:1313

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:5050/api/server/status || exit 1
 
 # 清理 Docker 挂载可能自动创建的 config.toml 目录（Hugo 会误读为配置文件）
-CMD ["sh", "-c", "rm -rf /app/config.toml && python app.py"]
+CMD ["sh", "-c", "test -d /app/config.toml && rm -rf /app/config.toml; python app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,18 +12,18 @@ services:
       - "5050:5050"  # Hugo Admin 管理界面
       - "1313:1313"  # Hugo 预览服务器
     volumes:
-      # 挂载 Hugo 博客内容目录（指向实际的 hugo-blog 目录）
-      - ../hugo-blog/content:/app/content
-      - ../hugo-blog/public:/app/public
-      - ../hugo-blog/static:/app/static
-      - ../hugo-blog/config:/app/config:ro
+      # 挂载 Hugo 博客内容目录（路径通过 .env 文件配置）
+      - ${HUGO_BLOG_DIR:-../hugo-blog}/content:/app/content
+      - ${HUGO_BLOG_DIR:-../hugo-blog}/public:/app/public
+      - ${HUGO_BLOG_DIR:-../hugo-blog}/static:/app/static
+      - ${HUGO_BLOG_DIR:-../hugo-blog}/config:/app/config:ro
       # 禁用 Hugo Modules，使用本地主题（覆盖为空文件）
       - /dev/null:/app/config/_default/module.toml
-      - ../hugo-blog/layouts:/app/layouts
-      - ../hugo-blog/assets:/app/assets
-      - ../hugo-blog/resources:/app/resources
-      # 主题目录：直接挂载实际的 Fried-Rice（Docker 不跟随符号链接）
-      - ../Fried-Rice:/app/themes/stack:ro
+      - ${HUGO_BLOG_DIR:-../hugo-blog}/layouts:/app/layouts
+      - ${HUGO_BLOG_DIR:-../hugo-blog}/assets:/app/assets
+      - ${HUGO_BLOG_DIR:-../hugo-blog}/resources:/app/resources
+      # 主题目录：直接挂载实际主题（Docker 不跟随符号链接）
+      - ${HUGO_THEME_DIR:-../Fried-Rice}:/app/themes/stack:ro
       # 持久化缓存数据库（挂载到 /app 外，避免 Hugo 读取 cache.db）
       - ./data:/hugo_admin_data
     environment:


### PR DESCRIPTION
## 改动

针对 PR #97 评审建议 #1 和 #2 的修复：

### #1 硬编码路径改用 `.env` 变量
- `docker-compose.yml` 中 `../hugo-blog/` 和 `../Fried-Rice/` 替换为 `${HUGO_BLOG_DIR:-../hugo-blog}` 和 `${HUGO_THEME_DIR:-../Fried-Rice}`
- 默认值保持不变，无需 `.env` 即可开箱使用
- 新增 `.env.example` 文件说明可配置项

### #2 `rm -rf` 改为条件删除
- Dockerfile CMD 中 `rm -rf /app/config.toml` 改为 `test -d /app/config.toml && rm -rf /app/config.toml`
- 仅当路径为目录时才删除，避免误删符号链接或真实配置文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)