### PR TITLE
feat: 编辑器页面显示文章标题

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { get } from '../utils/api';
+import { usePageTitle } from '../contexts/PageTitleContext';
 import type { ServerStatus } from '../types';
 
 const pageTitles: Record<string, string> = {
@@ -11,11 +12,20 @@ const pageTitles: Record<string, string> = {
   '/settings': '设置',
 };
 
+function matchPageTitle(pathname: string): string | undefined {
+  if (pageTitles[pathname]) return pageTitles[pathname];
+  for (const [path, title] of Object.entries(pageTitles)) {
+    if (pathname.startsWith(path + '/')) return title;
+  }
+  return undefined;
+}
+
 export default function Header() {
   const location = useLocation();
   const [status, setStatus] = useState<ServerStatus>({ running: false, pid: null });
+  const { title: articleTitle } = usePageTitle();
 
-  const pageTitle = pageTitles[location.pathname] || 'Hugo Blog 管理';
+  const matchedTitle = matchPageTitle(location.pathname);
 
   useEffect(() => {
     async function fetchStatus() {
@@ -34,7 +44,7 @@ export default function Header() {
   return (
     <header className="bg-white shadow-sm border-b border-stone-200 px-6 py-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-semibold text-stone-800">{pageTitle}</h2>
+        <h2 className="text-2xl font-semibold text-stone-800">{articleTitle || matchedTitle}</h2>
         <div className="flex items-center space-x-4">
           <div className="flex items-center space-x-2">
             <div

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,20 +3,23 @@ import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import AIChat from './AIChat';
+import { PageTitleProvider } from '../contexts/PageTitleContext';
 
 export default function Layout() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar collapsed={sidebarCollapsed} onToggle={() => setSidebarCollapsed(!sidebarCollapsed)} />
-      <main className="flex-1 overflow-auto bg-stone-50">
-        <Header />
-        <div className="p-6">
-          <Outlet />
-        </div>
-      </main>
-      <AIChat />
-    </div>
+    <PageTitleProvider>
+      <div className="flex h-screen overflow-hidden">
+        <Sidebar collapsed={sidebarCollapsed} onToggle={() => setSidebarCollapsed(!sidebarCollapsed)} />
+        <main className="flex-1 overflow-auto bg-stone-50">
+          <Header />
+          <div className="p-6">
+            <Outlet />
+          </div>
+        </main>
+        <AIChat />
+      </div>
+    </PageTitleProvider>
   );
 }

--- a/frontend/src/contexts/PageTitleContext.tsx
+++ b/frontend/src/contexts/PageTitleContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+const PageTitleContext = createContext<{
+  title: string;
+  setTitle: (title: string) => void;
+  resetTitle: () => void;
+}>({ title: '', setTitle: () => {}, resetTitle: () => {} });
+
+export function PageTitleProvider({ children }: { children: ReactNode }) {
+  const [title, setTitleState] = useState('');
+  const setTitle = useCallback((t: string) => setTitleState(t), []);
+  const resetTitle = useCallback(() => setTitleState(''), []);
+
+  return (
+    <PageTitleContext.Provider value={{ title, setTitle, resetTitle }}>
+      {children}
+    </PageTitleContext.Provider>
+  );
+}
+
+export function usePageTitle() {
+  return useContext(PageTitleContext);
+}

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -22,6 +22,7 @@ import {
 import { get, post } from '../utils/api';
 import { renderMarkdown } from '../utils/markdown';
 import type { FileData, ImageItem, Backlink, Frontmatter } from '../types';
+import { usePageTitle } from '../contexts/PageTitleContext';
 
 export default function Editor() {
   const { filePath, '*': restPath } = useParams();
@@ -62,6 +63,14 @@ export default function Editor() {
   insertMarkdownRef.current = insertMarkdown;
   const [generatingCover, setGeneratingCover] = useState(false);
   const [generatingFm, setGeneratingFm] = useState(false);
+  const { setTitle: setPageTitle, resetTitle: resetPageTitle } = usePageTitle();
+
+  useEffect(() => {
+    if (frontmatter.title) {
+      setPageTitle(frontmatter.title);
+    }
+    return () => { resetPageTitle(); };
+  }, [frontmatter.title, setPageTitle, resetPageTitle]);
 
   const currentFile = fullPath;
 


### PR DESCRIPTION
## 问题

`/editor/post/*.index` 等嵌套路由在 Header 中不匹配 `pageTitles`，回退显示硬编码的 "Hugo Blog 管理"。

## 方案

- 新增 `PageTitleContext`，让子页面可以向 Header 传递自定义标题
- Editor 加载 frontmatter 后将 `frontmatter.title` 写入 context，离开时清除
- Header 优先显示文章标题，其次通过前缀匹配路由页面名（如 `/editor/post/xxx` → "文章编辑器"）
- Layout 中用 `PageTitleProvider` 包裹，使 Header 与所有页面共享 context

## 测试

在 http://192.168.2.14:5053 上验证：进入编辑器页面后 Header 显示文章标题（如 "测试 cloudflare"），非编辑器页面显示路由对应的页面名。