### PR TITLE
fix: wire plugin_manager into ServiceRegistry

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,6 +150,7 @@ try:
     print(
         f"✓ 已加载 {len([p for p in plugin_manager.list_plugins() if p['enabled']])} 个插件"
     )
+    registry.plugin_manager = plugin_manager
 except Exception as e:
     print(f"⚠ 插件系统初始化失败: {e}")
 

--- a/services/registry.py
+++ b/services/registry.py
@@ -87,3 +87,11 @@ class ServiceRegistry:
     @socketio.setter
     def socketio(self, value):
         self._services["socketio"] = value
+
+    @property
+    def plugin_manager(self):
+        return self._services.get("plugin_manager")
+
+    @plugin_manager.setter
+    def plugin_manager(self, value):
+        self._services["plugin_manager"] = value


### PR DESCRIPTION
## Summary
`plugin_manager` was created in `app.py` but never added to the `ServiceRegistry`. This meant `image_routes._try_plugin_upload()` always got `None` from `registry.plugin_manager`, causing all image uploads to silently fall back to local disk instead of going through the configured plugin.

## Changes
- `app.py`: Add `registry.plugin_manager = plugin_manager` after plugin initialization
- `services/registry.py`: Add `plugin_manager` property with getter/setter

## Verified
- Uploaded image through editor → R2 URL returned and stored in article
- Public URL accessible: returns 200