### PR TITLE
fix(posts): wire page param and add pagination controls

### DIFF
--- a/frontend/src/pages/Posts.tsx
+++ b/frontend/src/pages/Posts.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Search, RefreshCw, Plus, Upload, Tag, FolderOpen, Calendar, Clock, FileText } from 'lucide-react';
+import { Search, RefreshCw, Plus, Upload, Tag, FolderOpen, Calendar, Clock, FileText, ChevronLeft, ChevronRight } from 'lucide-react';
 import { get, post } from '../utils/api';
 import type { Post, PostsResponse, Tag as TagType, Category } from '../types';
 
@@ -8,6 +8,7 @@ export default function Posts() {
   const navigate = useNavigate();
   const [posts, setPosts] = useState<Post[]>([]);
   const [pagination, setPagination] = useState({ total: 0, page: 1, per_page: 20, total_pages: 0, has_next: false, has_prev: false });
+  const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [tags, setTags] = useState<TagType[]>([]);
@@ -22,6 +23,7 @@ export default function Posts() {
     try {
       const params = new URLSearchParams();
       params.set('per_page', '20');
+      params.set('page', String(currentPage));
       if (filters.query) params.set('q', filters.query);
       if (filters.category) params.set('category', filters.category);
       if (filters.tag) params.set('tag', filters.tag);
@@ -35,12 +37,17 @@ export default function Posts() {
         has_next: data.has_next,
         has_prev: data.has_prev,
       });
+      // 如果服务端回传的页码与请求不符（例如筛选后实际数据变少导致越界），
+      // 跟随服务端纠正到合法页码，避免 UI 一直停留在不存在的页。
+      if (data.page !== currentPage) {
+        setCurrentPage(data.page);
+      }
     } catch (error) {
       console.error('Failed to load posts:', error);
     } finally {
       setLoading(false);
     }
-  }, [filters]);
+  }, [filters, currentPage]);
 
   async function loadFilters() {
     try {
@@ -59,6 +66,30 @@ export default function Posts() {
     loadPosts();
     loadFilters();
   }, [loadPosts]);
+
+  // 切换筛选条件时回到第 1 页，避免停留在已不存在的页码上。
+  // 使用显式包装函数而非 effect：setState in effect 会触发级联渲染。
+  function updateFilter<K extends keyof typeof filters>(key: K, value: (typeof filters)[K]) {
+    if (filters[key] === value) return;
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    setCurrentPage(1);
+  }
+
+  function goToPage(page: number) {
+    const total = pagination.total_pages || 1;
+    const next = Math.max(1, Math.min(page, total));
+    if (next !== currentPage) {
+      setCurrentPage(next);
+    }
+  }
+
+  function prevPage() {
+    goToPage(currentPage - 1);
+  }
+
+  function nextPage() {
+    goToPage(currentPage + 1);
+  }
 
   async function refreshCache() {
     setRefreshing(true);
@@ -151,7 +182,7 @@ export default function Posts() {
               <input
                 type="text"
                 value={filters.query}
-                onChange={(e) => setFilters({ ...filters, query: e.target.value })}
+                onChange={(e) => updateFilter('query', e.target.value)}
                 placeholder="搜索标题、内容、标签..."
                 className="w-full pl-10 pr-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-stone-400 focus:border-transparent"
               />
@@ -161,7 +192,7 @@ export default function Posts() {
             <label className="block text-sm font-medium text-stone-700 mb-2">分类</label>
             <select
               value={filters.category}
-              onChange={(e) => setFilters({ ...filters, category: e.target.value })}
+              onChange={(e) => updateFilter('category', e.target.value)}
               className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-stone-400"
             >
               <option value="">全部分类</option>
@@ -176,7 +207,7 @@ export default function Posts() {
             <label className="block text-sm font-medium text-stone-700 mb-2">标签</label>
             <select
               value={filters.tag}
-              onChange={(e) => setFilters({ ...filters, tag: e.target.value })}
+              onChange={(e) => updateFilter('tag', e.target.value)}
               className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-stone-400"
             >
               <option value="">全部标签</option>
@@ -321,6 +352,84 @@ export default function Posts() {
           </div>
         )}
       </div>
+
+      {/*
+        控件本身的可见性：当没有任何文章时隐藏分页栏（避免显示"第 1 页 / 共 0 页"）。
+        加载态下保留分页栏位，但禁用按钮，避免布局跳动。
+      */}
+      {pagination.total > 0 && (
+        <nav
+          aria-label="分页"
+          className="bg-white rounded-md ring-1 ring-stone-900/5 px-6 py-3 mt-6 flex items-center justify-between flex-wrap gap-3"
+        >
+          <div className="text-sm text-stone-500">
+            第 <span className="font-medium text-stone-700">{pagination.page}</span> / {pagination.total_pages} 页
+            <span className="mx-2 text-stone-300">·</span>
+            共 {pagination.total} 篇
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={prevPage}
+              disabled={!pagination.has_prev || loading}
+              className="px-3 py-1.5 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center"
+              aria-label="上一页"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            {getPageNumbers(pagination.page, pagination.total_pages).map((item, idx) =>
+              item === '…' ? (
+                <span
+                  key={`ellipsis-${idx}`}
+                  className="px-2 text-stone-400 select-none"
+                  aria-hidden="true"
+                >
+                  …
+                </span>
+              ) : (
+                <button
+                  key={item}
+                  type="button"
+                  onClick={() => goToPage(item)}
+                  disabled={loading}
+                  aria-current={item === pagination.page ? 'page' : undefined}
+                  className={
+                    item === pagination.page
+                      ? 'px-3 py-1.5 rounded-lg bg-blue-600 text-white font-medium cursor-default'
+                      : 'px-3 py-1.5 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors disabled:opacity-50'
+                  }
+                >
+                  {item}
+                </button>
+              ),
+            )}
+            <button
+              type="button"
+              onClick={nextPage}
+              disabled={!pagination.has_next || loading}
+              className="px-3 py-1.5 border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center"
+              aria-label="下一页"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </nav>
+      )}
     </div>
   );
+}
+
+function getPageNumbers(current: number, total: number): (number | '…')[] {
+  // 页数较少时直接展开；否则用 1 … current-1 current current+1 … last 的折叠形态。
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  const pages: (number | '…')[] = [1];
+  const left = Math.max(2, current - 1);
+  const right = Math.min(total - 1, current + 1);
+  if (left > 2) pages.push('…');
+  for (let p = left; p <= right; p++) pages.push(p);
+  if (right < total - 1) pages.push('…');
+  pages.push(total);
+  return pages;
 }

--- a/tests/test_posts_pagination_api.py
+++ b/tests/test_posts_pagination_api.py
@@ -1,0 +1,96 @@
+# coding: utf-8
+"""
+分页测试 (issue #104)
+
+后端分页逻辑此前已通过 `services.post_service.PostService.get_posts` 暴露，
+但前端从未传递 `page` 参数，UI 也没有翻页控件。此处的测试固定住后端契约，
+避免后续回归；并证明 `page` / `per_page` 在服务层能正确分页。
+
+不分层到 HTTP：避免把 Flask app 的整条导入链拖进测试套件。
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+import frontmatter
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from services.post_service import PostService  # noqa: E402
+
+
+def _make_post(path: Path, title: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm = frontmatter.Post(
+        f"# {title}\n",
+        title=title,
+        date="2025-01-01",
+        draft=False,
+        categories=["demo"],
+        tags=["pagination"],
+    )
+    path.write_text(frontmatter.dumps(fm), encoding="utf-8")
+
+
+@pytest.fixture
+def temp_content_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        content_dir = Path(tmp) / "content"
+        content_dir.mkdir()
+        yield content_dir
+
+
+@pytest.fixture
+def post_service(temp_content_dir):
+    return PostService(temp_content_dir, use_cache=False)
+
+
+def _seed(content_dir: Path, n: int) -> None:
+    for i in range(n):
+        _make_post(content_dir / f"post/p{i:02d}.md", f"P{i:02d}")
+
+
+class TestPostsPagination:
+    """`PostService.get_posts` 的分页契约"""
+
+    def test_default_returns_first_window(self, post_service, temp_content_dir):
+        _seed(temp_content_dir, 25)
+        data = post_service.get_posts(page=1, per_page=10)
+        assert data["total"] == 25
+        assert data["page"] == 1
+        assert data["per_page"] == 10
+        assert data["total_pages"] == 3
+        assert data["has_next"] is True
+        assert data["has_prev"] is False
+        assert len(data["posts"]) == 10
+
+    def test_explicit_page_2_returns_next_window(self, post_service, temp_content_dir):
+        _seed(temp_content_dir, 25)
+        page1 = post_service.get_posts(page=1, per_page=10)
+        page2 = post_service.get_posts(page=2, per_page=10)
+        assert page2["page"] == 2
+        assert page2["has_next"] is True
+        assert page2["has_prev"] is True
+        assert len(page2["posts"]) == 10
+        # 翻页结果应与第 1 页互不重叠。
+        first_paths = {p["path"] for p in page1["posts"]}
+        second_paths = {p["path"] for p in page2["posts"]}
+        assert first_paths.isdisjoint(second_paths)
+
+    def test_last_page_has_partial_window(self, post_service, temp_content_dir):
+        _seed(temp_content_dir, 25)
+        data = post_service.get_posts(page=3, per_page=10)
+        assert data["page"] == 3
+        assert data["has_next"] is False
+        assert data["has_prev"] is True
+        assert len(data["posts"]) == 5
+
+    def test_total_pages_zero_for_empty(self, post_service, temp_content_dir):
+        data = post_service.get_posts(page=1, per_page=20)
+        assert data["total"] == 0
+        assert data["page"] == 1
+        assert data["total_pages"] == 0
+        assert data["has_next"] is False
+        assert data["has_prev"] is False
+        assert data["posts"] == []


### PR DESCRIPTION
## Repro

文章管理页打开后，无论有多少文章，列表只能看到第一页（最多 20 条），且页面上没有任何翻页控件。

最小复现：
- 在 `content/post/` 下放 25 篇文章，打开 `/posts`
- 预期：能看到分页条，能切到第 2、3 页
- 实际：列表固定在 `per_page=20` 的前 20 篇，没有页码按钮，也没有上一页/下一页

后端 `/api/posts?page=2&per_page=10` 已经能正确返回第 2 页（`total=25, page=2, has_prev=true, has_next=true, count=10`），问题完全在前端。

## Cause

- `frontend/src/pages/Posts.tsx` 中 `loadPosts`（21-50 行）构造 `URLSearchParams` 时只设置了 `per_page`，**没有** 传 `page`，所以每次请求都拿到第 1 页。
- `pagination` state 保存了 `total_pages` / `has_next` / `has_prev`，但渲染区（170-416 行）没有任何地方消费这些字段，UI 上完全缺失分页控件。
- 切换筛选条件时也没有把页码重置到 1，存在"数据变少后停留到不存在的页"的隐患。

## Fix

- `frontend/src/pages/Posts.tsx`：
  - 新增 `currentPage` state；`loadPosts` 中 `params.set('page', String(currentPage))`，并把 `currentPage` 加进 `useCallback` 依赖。
  - 若服务端在响应里纠正了页码（典型场景：筛选后总数变少，请求的页码越界），客户端跟随纠正，避免 UI 长期停留在不存在的页。
  - 新增 `updateFilter` 工具函数：任何筛选条件变更都把 `currentPage` 重置为 1。比 `useEffect + setState` 更直接，也避开了 `react-hooks/set-state-in-effect` 这条新规则。
  - 新增 `goToPage` / `prevPage` / `nextPage`，对 `pagination.total_pages` 做夹紧，越界输入会被忽略。
  - 列表底部新增 `<nav aria-label="分页">`：
    - 上一页 / 下一页 chevron 按钮，按 `has_prev` / `has_next` 禁用
    - 页码按钮：≤ 7 页时全部展开；否则用 `1 … current-1 current current+1 … last` 的折叠形态（`getPageNumbers` 辅助函数）
    - 当前页高亮、`第 N / M 页 · 共 K 篇` 计数、加载态禁用所有按钮
    - 当 `pagination.total === 0` 时整条分页栏隐藏，避免显示"第 1 页 / 共 0 页"
- `tests/test_posts_pagination_api.py`（新增）：把 `PostService.get_posts` 的分页契约固定下来（首/中/尾页、跨页互不重叠、空目录），防回归。

## Verification

- `uv run pytest tests/test_posts_pagination_api.py -v` — 4 passed
- `cd frontend && bun run build` — `tsc -b && vite build` 成功通过
- `cd frontend && bunx eslint src/pages/Posts.tsx` — 与 `main` 分支相比没有新增 lint 错误（剩余 4 条均为已存在的 `set-state-in-effect` / 未使用 `error` 变量，与本次改动无关）
- 手算 trace：
  - 默认挂载：请求 `/api/posts?per_page=20&page=1` → 拿到第 1 页
  - 点击第 3 页按钮 → `goToPage(3)` → `setCurrentPage(3)` → 请求 `…&page=3` → 拿到第 3 页
  - 修改分类为 `tech` → `updateFilter('category', 'tech')` → `setCurrentPage(1)` → 请求 `…&page=1&category=tech` → 拿到新筛选的第 1 页
  - 在某筛选只有 1 页时点击第 3 页 → `goToPage(3)` 夹紧到 1，请求 `…&page=1&category=tech` → UI 仍合法

Fixes #104