### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-06-11
+
+### Added
+- Plugin system implementation (Phase 1 + Phase 2): gRPC-based extension architecture
+- Plugin management UI page
+- Editor image upload wired to active image plugin
+- Listmonk configuration to settings page with auto-migration from `~/.config/secret.yml`
+- AI assistant awareness of current page and article context
+- 80 unit tests for plugin system
+
+### Changed
+- Split README into English and Chinese versions
+- Add Docker installation instructions to README
+- Posts pagination: wire page param and add pagination controls
+
+### Fixed
+- Extract `tool_result` text content in backend and show preview in summary
+- Fix SSE chunk boundary causing `tool_result` JSON to be rendered as text
+- Fix undefined `session_id` when extracting `tool_result`
+- Wire `plugin_manager` into `ServiceRegistry`
+- Show article title (instead of static text) on editor page
+- Docker deployment: mount hugo-blog dirs, support env-var paths
+- Address PR review suggestions for docker-deploy
+
 ## [2.1.1] - 2026-06-07
 
 ### Added

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "1.3.0"
+__version__ = "2.2.0"
 __version_info__ = tuple(int(x) for x in __version__.split("."))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.4.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.2.0",
   "type": "module",
   "packageManager": "pnpm@9.15.0",
   "engines": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hugo-admin"
-version = "2.1.1"
+version = "2.2.0"
 description = "A lightweight web-based admin interface for managing Hugo static sites"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

- Bump version 2.1.1 → 2.2.0 (sync `__version__.py` which was stale at 1.3.0)
- Sync `frontend/package.json` and `package-lock.json` to 2.2.0
- Add CHANGELOG entry for v2.2.0 covering all unreleased changes since v2.1.1:
  - Plugin system (Phase 1+2): gRPC extension architecture, management UI, image upload wired to active plugin, ServiceRegistry wiring (#92, #93, #94, #95, #96, #98, #99, #100, #101, #102)
  - Listmonk settings page with auto-migration from `~/.config/secret.yml` (#103)
  - AI assistant page/article context awareness
  - Posts pagination controls (#105)
  - Docker deployment fixes (mount hugo-blog dirs, env-var paths) (#97, #98)
  - AI `tool_result` extraction and SSE chunk-boundary fixes
  - 80 unit tests for plugin system
  - README split into English/Chinese versions, Docker install docs

## Test plan

- [x] Pre-commit hooks (flake8, black, isort) pass
- [ ] CI: backend tests
- [ ] CI: frontend build
- [ ] Verify `__version__` imports correctly: `python -c "import sys; sys.path.insert(0, 'src'); from __version__ import __version__; print(__version__)"`
- [ ] Verify frontend builds: `cd frontend && pnpm install && pnpm build`

🤖 Generated with [Crush](https://crush.example)

Assisted-by: Crush:MiniMax-M3