### PR TITLE
feat(editor): inline AI edit (rewrite) for selected text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Inline AI edit (rewrite) in the editor: select text → floating ✨ trigger → instruction input + 4 Chinese presets (润色 / 翻译为英文 / 精简 / 详细化) → non-streaming LLM call → original-vs-revised side-by-side diff → accept replaces the selection. Backed by a new `POST /api/ai/inline-edit` endpoint and `AIService.quick_rewrite` (Claude Agent SDK with tools disabled, 10s timeout).
+- Tests for the new endpoint and the `quick_rewrite` service method.
+
 ## [2.2.0] - 2026-06-11
 
 ### Added

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from routes import (
     register_email_routes,
     register_file_routes,
     register_image_routes,
+    register_inline_edit_routes,
     register_page_routes,
     register_post_routes,
     register_publish_routes,
@@ -214,6 +215,7 @@ app.register_blueprint(register_settings_routes(app, registry))
 ai_main_bp, fm_bp = register_ai_routes(get_ai_service)
 app.register_blueprint(ai_main_bp)
 app.register_blueprint(fm_bp)
+app.register_blueprint(register_inline_edit_routes(get_ai_service))
 app.register_blueprint(register_plugin_routes(plugin_manager))
 
 # ============ 注册 SocketIO 事件 ============

--- a/frontend/src/components/InlineEdit/Overlay.tsx
+++ b/frontend/src/components/InlineEdit/Overlay.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Popup } from './Popup';
+import { Trigger } from './Trigger';
+
+const MIN_SELECTION = 3;
+const MAX_SELECTION = 5000;
+const DEBOUNCE_MS = 300;
+const CONTEXT_RADIUS = 600;
+const TRIGGER_SIZE = 36;
+const VIEWPORT_MARGIN = 8;
+
+export interface InlineEditOverlayProps {
+  /** The textarea that the editor is rendering. */
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  /** Source of truth for the editor content (used to slice context). */
+  content: string;
+  /**
+   * Called when the user accepts a rewrite and the selection has not drifted.
+   * Receives the revised text and the original anchor range so the host can
+   * perform the actual `setContent` + `setSelectionRange`.
+   */
+  onAccept: (revisedText: string, anchorStart: number, anchorEnd: number) => void;
+  /** Called when the user accepts a rewrite but the selection has drifted. */
+  onDrift?: () => void;
+}
+
+interface Anchor {
+  start: number;
+  end: number;
+  text: string;
+  contextBefore: string;
+  contextAfter: string;
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+/**
+ * Selection-anchored AI rewrite surface for a `<textarea>`.
+ *
+ * Tracks the textarea's selection; shows a floating trigger near the end of a
+ * non-empty selection; opens a popup on click; passes the rewrite result back
+ * to the host on accept. Selection drift is caught at accept time by
+ * re-reading `textarea.value` and comparing against the snapshotted
+ * `selectedText`.
+ */
+export function InlineEditOverlay({
+  textareaRef,
+  onAccept,
+  onDrift,
+}: InlineEditOverlayProps) {
+  const [anchor, setAnchor] = useState<Anchor | null>(null);
+  const [open, setOpen] = useState(false);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const closeAll = useCallback(() => {
+    setOpen(false);
+    setAnchor(null);
+  }, []);
+
+  const onSelectionChange = useCallback(() => {
+    if (!aliveRef.current) return;
+    const ta = textareaRef.current;
+    if (!ta) return;
+    if (open) return; // freeze anchor while popup is open
+    const start = ta.selectionStart;
+    const end = ta.selectionEnd;
+    if (start === end) {
+      setAnchor(null);
+      return;
+    }
+    const text = ta.value.substring(start, end);
+    if (text.length < MIN_SELECTION || text.length > MAX_SELECTION) {
+      setAnchor(null);
+      return;
+    }
+    setAnchor({
+      start,
+      end,
+      text,
+      contextBefore: ta.value.substring(Math.max(0, start - CONTEXT_RADIUS), start),
+      contextAfter: ta.value.substring(end, Math.min(ta.value.length, end + CONTEXT_RADIUS)),
+    });
+  }, [textareaRef, open]);
+
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    let timer: number | null = null;
+    const schedule = () => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        timer = null;
+        onSelectionChange();
+      }, DEBOUNCE_MS);
+    };
+    const events: (keyof HTMLElementEventMap)[] = ['select', 'keyup', 'mouseup', 'focus'];
+    events.forEach((e) => ta.addEventListener(e, schedule));
+    return () => {
+      if (timer !== null) window.clearTimeout(timer);
+      events.forEach((e) => ta.removeEventListener(e, schedule));
+    };
+  }, [textareaRef, onSelectionChange]);
+
+  // Hide on scroll: position would go stale.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const onScroll = () => closeAll();
+    ta.addEventListener('scroll', onScroll, { passive: true });
+    return () => ta.removeEventListener('scroll', onScroll);
+  }, [textareaRef, closeAll]);
+
+  // Click outside the popup → close.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('[data-inline-edit-root="true"]')) return;
+      closeAll();
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [open, closeAll]);
+
+  const handleAccept = useCallback(
+    (revised: string) => {
+      const ta = textareaRef.current;
+      if (!ta || !anchor) {
+        closeAll();
+        return;
+      }
+      const current = ta.value.substring(anchor.start, anchor.end);
+      if (current !== anchor.text) {
+        onDrift?.();
+        closeAll();
+        return;
+      }
+      onAccept(revised, anchor.start, anchor.end);
+      closeAll();
+    },
+    [textareaRef, anchor, onAccept, onDrift, closeAll],
+  );
+
+  if (!anchor) return null;
+  const ta = textareaRef.current;
+  if (!ta) return null;
+
+  // Approximate the viewport position of the selection end.
+  // We don't have line-level pixel coords for a textarea, so we use a
+  // best-effort approach: number of newlines up to `end` × line-height,
+  // plus a small horizontal offset. This is rough but stable enough for a
+  // 36×36 button and matches what the user sees.
+  const rect = ta.getBoundingClientRect();
+  const cs = window.getComputedStyle(ta);
+  const lineHeight = parseFloat(cs.lineHeight) || 22;
+  const paddingTop = parseFloat(cs.paddingTop) || 0;
+  const paddingLeft = parseFloat(cs.paddingLeft) || 0;
+  const textBeforeEnd = ta.value.substring(0, anchor.end);
+  const linesBefore = textBeforeEnd.split('\n').length - 1;
+  const lastLine = textBeforeEnd.split('\n').pop() || '';
+  // Rough character width for monospace 14px ≈ 8.4px. We don't have
+  // canvas-measured char width, so this is a heuristic. The trigger clamps
+  // itself to the viewport, so being slightly off is fine.
+  const charWidth = 8.4;
+  const approxLeft = rect.left + paddingLeft + Math.min(lastLine.length, 80) * charWidth + 6;
+  const approxTop = rect.top + paddingTop + linesBefore * lineHeight + 2;
+
+  if (open) {
+    const popupWidth = 320;
+    const left = clamp(
+      approxLeft,
+      VIEWPORT_MARGIN,
+      Math.max(VIEWPORT_MARGIN, window.innerWidth - popupWidth - VIEWPORT_MARGIN),
+    );
+    const popupHeightEstimate = 280;
+    const below = approxTop + 8;
+    const top =
+      below + popupHeightEstimate > window.innerHeight
+        ? Math.max(VIEWPORT_MARGIN, approxTop - popupHeightEstimate - 8)
+        : below;
+    return (
+      <div data-inline-edit-root="true">
+        <Popup
+          selectedText={anchor.text}
+          contextBefore={anchor.contextBefore}
+          contextAfter={anchor.contextAfter}
+          top={top}
+          left={left}
+          onClose={closeAll}
+          onAccept={handleAccept}
+        />
+      </div>
+    );
+  }
+
+  // Trigger mode
+  const triggerTop = clamp(
+    approxTop - 2,
+    VIEWPORT_MARGIN,
+    Math.max(VIEWPORT_MARGIN, window.innerHeight - TRIGGER_SIZE - VIEWPORT_MARGIN),
+  );
+  const triggerLeft = clamp(
+    approxLeft,
+    VIEWPORT_MARGIN,
+    Math.max(VIEWPORT_MARGIN, window.innerWidth - TRIGGER_SIZE - VIEWPORT_MARGIN),
+  );
+  return (
+    <div data-inline-edit-root="true">
+      <Trigger
+        top={triggerTop}
+        left={triggerLeft}
+        onClick={() => setOpen(true)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/InlineEdit/Popup.tsx
+++ b/frontend/src/components/InlineEdit/Popup.tsx
@@ -1,0 +1,196 @@
+import { Loader2, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { INLINE_EDIT_PRESETS } from './presets';
+import { post } from '../../utils/api';
+
+export interface PopupProps {
+  selectedText: string;
+  contextBefore: string;
+  contextAfter: string;
+  /** Viewport-relative top (px). */
+  top: number;
+  /** Viewport-relative left (px). */
+  left: number;
+  onClose: () => void;
+  onAccept: (revisedText: string) => void;
+}
+
+interface InlineEditResponse {
+  success: boolean;
+  revised_text?: string;
+  model?: string;
+  message?: string;
+}
+
+export function Popup({
+  selectedText,
+  contextBefore,
+  contextAfter,
+  top,
+  left,
+  onClose,
+  onAccept,
+}: PopupProps) {
+  const [instruction, setInstruction] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  async function send(instructionText: string) {
+    const trimmed = instructionText.trim();
+    if (!trimmed || loading) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const resp = await post<InlineEditResponse>('/api/ai/inline-edit', {
+        selected_text: selectedText,
+        instruction: trimmed,
+        context_before: contextBefore,
+        context_after: contextAfter,
+      });
+      if (!aliveRef.current) return;
+      if (!resp.success || !resp.revised_text) {
+        setError(resp.message || '改写失败');
+      } else {
+        setResult(resp.revised_text);
+      }
+    } catch (err) {
+      if (!aliveRef.current) return;
+      setError(err instanceof Error ? err.message : '改写失败');
+    } finally {
+      if (aliveRef.current) setLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>) {
+    if (e.key === 'Enter' && !e.shiftKey && e.currentTarget.tagName === 'TEXTAREA') {
+      e.preventDefault();
+      e.stopPropagation();
+      void send(instruction);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="AI 改写"
+      onKeyDown={handleKeyDown}
+      onMouseDown={(e) => e.stopPropagation()}
+      className="fixed z-[60] flex w-80 flex-col gap-2 rounded-lg border border-stone-200 bg-white p-3 shadow-2xl"
+      style={{ top, left }}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-stone-700">快速改写</span>
+        <button
+          type="button"
+          aria-label="关闭"
+          onClick={onClose}
+          className="rounded p-1 text-stone-400 hover:bg-stone-100 hover:text-stone-600"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {result === null ? (
+        <>
+          <textarea
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="输入改写指令，或点击下方预设…"
+            autoFocus
+            rows={2}
+            disabled={loading}
+            className="resize-none rounded-md border border-stone-200 bg-white px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-stone-400 disabled:opacity-60"
+          />
+          <div className="flex flex-wrap gap-1.5">
+            {INLINE_EDIT_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                disabled={loading}
+                onClick={() => void send(preset.instruction)}
+                className="h-6 rounded-md border border-stone-200 bg-stone-50 px-2 text-xs text-stone-700 hover:bg-stone-100 disabled:opacity-60"
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+          {error && <p className="text-xs text-red-600">{error}</p>}
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="rounded-md px-2 py-1 text-xs text-stone-600 hover:bg-stone-100 disabled:opacity-60"
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              onClick={() => void send(instruction)}
+              disabled={loading || instruction.trim().length === 0}
+              className="rounded-md bg-stone-900 px-2 py-1 text-xs text-white hover:bg-stone-700 disabled:opacity-60 inline-flex items-center gap-1"
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  改写中…
+                </>
+              ) : (
+                '发送'
+              )}
+            </button>
+          </div>
+        </>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <div className="rounded-md border border-stone-200 bg-stone-50 p-2">
+            <div className="mb-1 text-[11px] font-medium text-stone-500">原文</div>
+            <pre className="max-h-24 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-stone-600">
+              {selectedText}
+            </pre>
+          </div>
+          <div className="rounded-md border border-stone-300 bg-white p-2">
+            <div className="mb-1 text-[11px] font-medium text-stone-900">改写</div>
+            <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed">
+              {result}
+            </pre>
+          </div>
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => {
+                setResult(null);
+                setError(null);
+              }}
+              className="rounded-md px-2 py-1 text-xs text-stone-600 hover:bg-stone-100"
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              onClick={() => onAccept(result)}
+              className="rounded-md bg-stone-900 px-2 py-1 text-xs text-white hover:bg-stone-700"
+            >
+              接受
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/InlineEdit/Trigger.tsx
+++ b/frontend/src/components/InlineEdit/Trigger.tsx
@@ -1,0 +1,29 @@
+import { Sparkles } from 'lucide-react';
+
+export interface TriggerProps {
+  /** Viewport-relative top (px). */
+  top: number;
+  /** Viewport-relative left (px). */
+  left: number;
+  onClick: () => void;
+}
+
+/**
+ * Small floating ✨ button shown at the user's text selection.
+ * Position is viewport-relative, so we use position: fixed.
+ */
+export function Trigger({ top, left, onClick }: TriggerProps) {
+  return (
+    <button
+      type="button"
+      aria-label="AI 改写"
+      title="AI 改写"
+      onClick={onClick}
+      onMouseDown={(e) => e.preventDefault()}
+      style={{ top, left }}
+      className="fixed z-50 h-9 w-9 rounded-full p-0 shadow-lg bg-stone-900 text-white hover:bg-stone-700 transition-transform hover:scale-105 flex items-center justify-center"
+    >
+      <Sparkles className="h-5 w-5" />
+    </button>
+  );
+}

--- a/frontend/src/components/InlineEdit/presets.ts
+++ b/frontend/src/components/InlineEdit/presets.ts
@@ -1,0 +1,30 @@
+export interface InlineEditPreset {
+  id: string;
+  /** Chinese chip label shown in the popup. */
+  label: string;
+  /** The instruction text sent to the LLM. */
+  instruction: string;
+}
+
+export const INLINE_EDIT_PRESETS: InlineEditPreset[] = [
+  {
+    id: 'polish',
+    label: '润色',
+    instruction: '请润色这段文字，保留原意，让表达更流畅、更专业。',
+  },
+  {
+    id: 'translate-en',
+    label: '翻译为英文',
+    instruction: '请将这段文字翻译为英文，保持原意、语气和格式。',
+  },
+  {
+    id: 'shorten',
+    label: '精简',
+    instruction: '请精简这段文字，保留核心信息，让表达更紧凑。',
+  },
+  {
+    id: 'expand',
+    label: '详细化',
+    instruction: '请扩写这段文字，补充更多细节和说明。',
+  },
+];

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -23,6 +23,7 @@ import { get, post } from '../utils/api';
 import { renderMarkdown } from '../utils/markdown';
 import type { FileData, ImageItem, Backlink, Frontmatter } from '../types';
 import { usePageTitle } from '../contexts/PageTitleContext';
+import { InlineEditOverlay } from '../components/InlineEdit/Overlay';
 
 export default function Editor() {
   const { filePath, '*': restPath } = useParams();
@@ -265,6 +266,25 @@ export default function Editor() {
       textarea.focus();
       textarea.setSelectionRange(start + cursorOffset, start + cursorOffset);
     });
+  }
+
+  function applyInlineEdit(revisedText: string, anchorStart: number, anchorEnd: number) {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const newContent =
+      content.substring(0, anchorStart) + revisedText + content.substring(anchorEnd);
+    setContent(newContent);
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(
+        anchorStart,
+        anchorStart + revisedText.length,
+      );
+    });
+  }
+
+  function handleInlineEditDrift() {
+    showNotification('选区已变化，已取消', 'warning');
   }
 
   async function loadFile() {
@@ -685,6 +705,12 @@ export default function Editor() {
               placeholder="在此输入 Markdown 内容..."
               className="flex-1 w-full font-mono text-sm p-4 border border-stone-200 rounded-lg bg-white resize-none focus:ring-2 focus:ring-stone-400 focus:border-transparent outline-none"
               style={{ lineHeight: 1.6 }}
+            />
+            <InlineEditOverlay
+              textareaRef={textareaRef}
+              content={content}
+              onAccept={applyInlineEdit}
+              onDrift={handleInlineEditDrift}
             />
           </div>
           <div className="flex flex-col">

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -8,6 +8,7 @@ from .ai_routes import register_ai_routes
 from .email_routes import register_email_routes
 from .file_routes import register_file_routes
 from .image_routes import register_image_routes
+from .inline_edit_routes import register_inline_edit_routes
 from .page_routes import register_page_routes
 from .plugin_routes import register_plugin_routes
 from .post_routes import register_post_routes
@@ -29,5 +30,6 @@ __all__ = [
     "register_settings_routes",
     "register_socketio_handlers",
     "register_ai_routes",
+    "register_inline_edit_routes",
     "register_plugin_routes",
 ]

--- a/routes/inline_edit_routes.py
+++ b/routes/inline_edit_routes.py
@@ -16,6 +16,25 @@ from services.ai_service import InlineEditEmptyResultError, InlineEditTimeoutErr
 
 logger = logging.getLogger(__name__)
 
+# Per-field input size caps. The frontend already constrains the selection
+# to 5000 chars and slices 600 chars of context on either side, but the
+# backend must enforce its own ceiling: a malicious or buggy client could
+# otherwise submit arbitrarily large payloads and amplify the per-call LLM
+# cost on this unauthenticated endpoint.
+MAX_SELECTED_TEXT = 5000
+MAX_INSTRUCTION = 1000
+MAX_CONTEXT = 1000
+
+# Defense in depth against prompt injection: even though the inline-edit
+# response is currently rendered only as text in a <pre> element (no
+# dangerouslySetInnerHTML), reject any LLM output that contains obvious
+# HTML/script payloads so a future render path can never turn a poisoned
+# rewrite into an XSS sink.
+_DANGEROUS_RESPONSE_PATTERN = re.compile(
+    r"<\s*script\b|<\s*iframe\b|javascript\s*:|on\w+\s*=",
+    re.IGNORECASE,
+)
+
 
 def _looks_like_markdown(line: str) -> bool:
     """A line is treated as Markdown if it carries any Markdown syntax marker.
@@ -125,6 +144,38 @@ def register_inline_edit_routes(ai_service_factory):
                 jsonify({"success": False, "message": "缺少 instruction"}),
                 400,
             )
+        # Per-field size caps — see MAX_* constants. Anything over the cap
+        # is rejected before we hit the LLM, since each call costs money.
+        if len(selected_text) > MAX_SELECTED_TEXT:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": f"selected_text 超过 {MAX_SELECTED_TEXT} 字符限制",
+                    }
+                ),
+                400,
+            )
+        if len(instruction) > MAX_INSTRUCTION:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": f"instruction 超过 {MAX_INSTRUCTION} 字符限制",
+                    }
+                ),
+                400,
+            )
+        if len(context_before) > MAX_CONTEXT or len(context_after) > MAX_CONTEXT:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": f"context 超过 {MAX_CONTEXT} 字符限制",
+                    }
+                ),
+                400,
+            )
 
         ai_service = ai_service_factory()
         if not getattr(ai_service, "enabled", False):
@@ -169,21 +220,18 @@ def register_inline_edit_routes(ai_service_factory):
                 ),
                 504,
             )
+        # All other failure modes collapse to a generic user-facing message;
+        # the actual exception text is logged server-side only.
         except RuntimeError as e:
             logger.warning("quick_rewrite runtime error: %s", e)
             return (
-                jsonify({"success": False, "message": str(e)}),
+                jsonify({"success": False, "message": "改写失败，请稍后重试"}),
                 500,
             )
         except Exception as e:  # noqa: BLE001
-            logger.exception("quick_rewrite failed")
+            logger.exception("quick_rewrite failed: %s", e)
             return (
-                jsonify(
-                    {
-                        "success": False,
-                        "message": f"改写失败：{e}",
-                    }
-                ),
+                jsonify({"success": False, "message": "改写失败，请稍后重试"}),
                 500,
             )
 
@@ -201,6 +249,24 @@ def register_inline_edit_routes(ai_service_factory):
                     {
                         "success": False,
                         "message": "改写失败：模型无输出",
+                    }
+                ),
+                500,
+            )
+        # Reject responses that look like they'd become XSS if a future
+        # render path ever trusts the model output. Today the response goes
+        # only into a <pre> text node and a <textarea>.value, both of which
+        # are safe, but this is a cheap defense-in-depth check.
+        if _DANGEROUS_RESPONSE_PATTERN.search(revised_text):
+            logger.warning(
+                "inline-edit response rejected: dangerous payload | raw=%r",
+                revised_text[:200],
+            )
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "改写失败：模型返回不安全内容",
                     }
                 ),
                 500,

--- a/routes/inline_edit_routes.py
+++ b/routes/inline_edit_routes.py
@@ -1,0 +1,217 @@
+# coding: utf-8
+"""
+Inline AI edit rewrite endpoint.
+
+A lightweight non-streaming LLM call that rewrites a small Markdown fragment
+selected in the editor. Backed by ``AIService.quick_rewrite`` (Claude Agent
+SDK with tools disabled).
+"""
+
+import logging
+import re
+
+from flask import Blueprint, jsonify, request
+
+from services.ai_service import InlineEditEmptyResultError, InlineEditTimeoutError
+
+logger = logging.getLogger(__name__)
+
+
+def _looks_like_markdown(line: str) -> bool:
+    """A line is treated as Markdown if it carries any Markdown syntax marker.
+
+    Blank lines count as Markdown (they're neutral).  Plain prose — including
+    Chinese sentences without any markdown marker — does NOT count, because
+    the inline-edit result is allowed to be plain prose and stripping it
+    would discard the model's actual answer.
+    """
+    s = line.strip()
+    if not s:
+        return True
+    return bool(re.search(r"(`|#|\*\*|\[|>|\* |- |\+ |\d+\. )", s))
+
+
+def _unwrap_single_fence(text: str) -> tuple[str, bool]:
+    """If ``text`` is a single fenced code block, return its contents.
+
+    Returns ``(new_text, fired)``. ``fired`` is True when the unwrap actually
+    applied. The whole-document case where the model wrapped the entire
+    response in ```markdown ... ``` is the one we unwrap; a single block
+    surrounded by other text is left alone.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text, False
+    if not stripped.endswith("```"):
+        return text, False
+    body = stripped[3:-3]
+    # Detect a single fence: no inner ``` fences.
+    if "```" in body:
+        return text, False
+    # Drop optional language tag on the first line ("```markdown\n...\n```").
+    lines = body.splitlines()
+    if lines and lines[0].strip() and not _looks_like_markdown(lines[0]):
+        # First line is just a language identifier like 'markdown'.
+        if re.match(r"^[a-zA-Z0-9_+\-]+$", lines[0].strip()):
+            lines = lines[1:]
+    inner = "\n".join(lines).strip()
+    if not inner:
+        return text, False
+    return inner, True
+
+
+def _post_process(raw: str) -> tuple[str, list[str]]:
+    """Run the post-processing fallbacks. Returns ``(clean, log_reasons)``.
+
+    We only handle the case where the model wrapped the whole response in a
+    single fenced code block.  We do NOT strip "leading non-Markdown lines" —
+    that heuristic is unsafe for plain-prose selections (Chinese sentences
+    without any markdown marker) and was the source of false negatives.
+    """
+    reasons: list[str] = []
+    text = raw.strip()
+    text, fired = _unwrap_single_fence(text)
+    if fired:
+        reasons.append("unwrapped_single_fence")
+    return text, reasons
+
+
+def _build_prompts(
+    selected_text: str,
+    instruction: str,
+    context_before: str,
+    context_after: str,
+) -> tuple[str, str]:
+    system_prompt = (
+        "你是一个 Markdown 改写助手。"
+        "用户会给你一段 Markdown 片段和它前后的上下文，以及改写指令。"
+        "你只输出改写后的 Markdown 片段本身，不要任何解释、前缀、后缀、"
+        "代码块包裹或换行声明。"
+    )
+    user_prompt = (
+        f"上下文（前）：\n{context_before}\n\n"
+        f"需要改写的片段：\n{selected_text}\n\n"
+        f"上下文（后）：\n{context_after}\n\n"
+        f"改写指令：{instruction}"
+    )
+    return system_prompt, user_prompt
+
+
+def register_inline_edit_routes(ai_service_factory):
+    """Register the inline-edit blueprint.
+
+    ``ai_service_factory`` mirrors the existing pattern used by
+    ``register_ai_routes`` — a no-arg callable that returns the current
+    ``AIService`` (or its ``_DisabledAIService`` mock when the API key is
+    unset).
+    """
+    inline_edit_bp = Blueprint("inline_edit", __name__, url_prefix="/api/ai")
+
+    @inline_edit_bp.route("/inline-edit", methods=["POST"])
+    def inline_edit():
+        data = request.get_json(silent=True) or {}
+        selected_text = (data.get("selected_text") or "").strip()
+        instruction = (data.get("instruction") or "").strip()
+        context_before = (data.get("context_before") or "").strip()
+        context_after = (data.get("context_after") or "").strip()
+
+        if not selected_text:
+            return (
+                jsonify({"success": False, "message": "缺少 selected_text"}),
+                400,
+            )
+        if not instruction:
+            return (
+                jsonify({"success": False, "message": "缺少 instruction"}),
+                400,
+            )
+
+        ai_service = ai_service_factory()
+        if not getattr(ai_service, "enabled", False):
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "AI service not configured. "
+                        "Set DEEPSEEK_API_KEY to enable.",
+                    }
+                ),
+                503,
+            )
+
+        system_prompt, user_prompt = _build_prompts(
+            selected_text, instruction, context_before, context_after
+        )
+
+        import anyio
+
+        try:
+            revised_text = anyio.run(
+                ai_service.quick_rewrite, system_prompt, user_prompt
+            )
+        except InlineEditEmptyResultError:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "改写失败：模型无输出",
+                    }
+                ),
+                500,
+            )
+        except InlineEditTimeoutError:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "改写超时，请稍后重试",
+                    }
+                ),
+                504,
+            )
+        except RuntimeError as e:
+            logger.warning("quick_rewrite runtime error: %s", e)
+            return (
+                jsonify({"success": False, "message": str(e)}),
+                500,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.exception("quick_rewrite failed")
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": f"改写失败：{e}",
+                    }
+                ),
+                500,
+            )
+
+        cleaned, reasons = _post_process(revised_text)
+        if reasons:
+            logger.warning(
+                "inline-edit post-processing fired: %s | raw=%r",
+                ",".join(reasons),
+                revised_text[:200],
+            )
+            revised_text = cleaned
+        if not revised_text.strip():
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "改写失败：模型无输出",
+                    }
+                ),
+                500,
+            )
+
+        return jsonify(
+            {
+                "success": True,
+                "revised_text": revised_text,
+                "model": getattr(ai_service, "model_name", "unknown"),
+            }
+        )
+
+    return inline_edit_bp

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -1,12 +1,15 @@
 """AI Service using Claude Agent SDK with DeepSeek provider."""
 
+import asyncio
 import os
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from claude_agent_sdk import (
+    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
+    TextBlock,
     create_sdk_mcp_server,
     tool,
 )
@@ -14,6 +17,17 @@ from claude_agent_sdk import (
 from services.git_service import GitService
 from services.hugo_service import HugoServerManager
 from services.post_service import PostService
+
+# Inline edit rewrite path
+INLINE_EDIT_TIMEOUT_S = 10.0
+
+
+class InlineEditEmptyResultError(RuntimeError):
+    """Raised when quick_rewrite completes but the model returns no text."""
+
+
+class InlineEditTimeoutError(RuntimeError):
+    """Raised when quick_rewrite exceeds the configured timeout."""
 
 
 @dataclass
@@ -207,3 +221,67 @@ class AIService:
             # Stream responses
             async for msg in client.receive_response():
                 yield msg
+
+    def _build_quick_rewrite_options(
+        self,
+        system_prompt: str,
+    ) -> ClaudeAgentOptions:
+        """Build a one-off ClaudeAgentOptions for the non-streaming rewrite path.
+
+        Tools are disabled, streaming is off, and the configured model is reused.
+        """
+        if not self.enabled:
+            raise RuntimeError("AI service is not configured")
+        return ClaudeAgentOptions(
+            model=self.model_name,
+            allowed_tools=[],
+            include_partial_messages=False,
+            env={
+                "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": os.environ.get("ANTHROPIC_AUTH_TOKEN", ""),
+                "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_AUTH_TOKEN", ""),
+                "ANTHROPIC_MODEL": self.model_name,
+            },
+            system_prompt=system_prompt,
+        )
+
+    async def quick_rewrite(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        timeout_s: float = INLINE_EDIT_TIMEOUT_S,
+    ) -> str:
+        """Run a single non-streaming LLM call for the inline-edit rewrite.
+
+        The agent is invoked with tools disabled and `include_partial_messages`
+        off, so the SDK returns a single ``AssistantMessage`` we can fully
+        buffer. Bounded by ``timeout_s``; on timeout raises
+        :class:`InlineEditTimeoutError`, on empty result raises
+        :class:`InlineEditEmptyResultError`.
+        """
+        if not self.enabled:
+            raise RuntimeError("AI service is not configured")
+
+        options = self._build_quick_rewrite_options(system_prompt)
+
+        async def _run() -> str:
+            async with ClaudeSDKClient(options=options) as client:
+                await client.query(user_prompt)
+                parts: List[str] = []
+                async for msg in client.receive_response():
+                    if isinstance(msg, AssistantMessage):
+                        for block in msg.content:
+                            if isinstance(block, TextBlock) and block.text:
+                                parts.append(block.text)
+                return "".join(parts).strip()
+
+        try:
+            result = await asyncio.wait_for(_run(), timeout=timeout_s)
+        except asyncio.TimeoutError as e:
+            raise InlineEditTimeoutError(
+                f"quick_rewrite timed out after {timeout_s}s"
+            ) from e
+
+        if not result:
+            raise InlineEditEmptyResultError("quick_rewrite returned empty text")
+        return result

--- a/tests/test_ai_quick_rewrite.py
+++ b/tests/test_ai_quick_rewrite.py
@@ -1,0 +1,209 @@
+# coding: utf-8
+"""
+Unit tests for ``AIService.quick_rewrite``.
+
+The Claude Agent SDK is mocked at the ``ClaudeSDKClient`` boundary so the
+tests don't hit the network and don't depend on a real LLM.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from claude_agent_sdk import AssistantMessage, TextBlock
+
+from services.ai_service import (
+    AIService,
+    InlineEditEmptyResultError,
+    InlineEditTimeoutError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assistant_message(text: str) -> AssistantMessage:
+    block = MagicMock(spec=TextBlock)
+    block.text = text
+    msg = MagicMock(spec=AssistantMessage)
+    msg.content = [block]
+    return msg
+
+
+class _StubAsyncIter:
+    """Minimal async iterator over a fixed list of messages."""
+
+    def __init__(self, items):
+        self._items = list(items)
+        self._i = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._i >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._i]
+        self._i += 1
+        return item
+
+
+def _make_service(enabled: bool = True) -> AIService:
+    """Build an AIService without running __init__'s network-touching code."""
+    svc = AIService.__new__(AIService)
+    svc.enabled = enabled
+    svc.model_name = "test-model"
+    svc.mcp_server = None
+    svc.options = None
+    svc.deps = None
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# quick_rewrite
+# ---------------------------------------------------------------------------
+
+
+class TestQuickRewrite:
+    @pytest.mark.asyncio
+    async def test_returns_aggregated_text(self):
+        svc = _make_service()
+
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_client.receive_response = MagicMock(
+            return_value=_StubAsyncIter(
+                [_assistant_message("hello "), _assistant_message("world")]
+            )
+        )
+
+        with patch(
+            "services.ai_service.ClaudeSDKClient",
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=mock_client),
+                __aexit__=AsyncMock(return_value=False),
+            ),
+        ):
+            result = await svc.quick_rewrite("sys", "usr")
+
+        assert result == "hello world"
+        mock_client.query.assert_awaited_once_with("usr")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_result(self):
+        svc = _make_service()
+
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_client.receive_response = MagicMock(return_value=_StubAsyncIter([]))
+
+        with patch(
+            "services.ai_service.ClaudeSDKClient",
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=mock_client),
+                __aexit__=AsyncMock(return_value=False),
+            ),
+        ):
+            with pytest.raises(InlineEditEmptyResultError):
+                await svc.quick_rewrite("sys", "usr")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_whitespace_only_result(self):
+        svc = _make_service()
+
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_client.receive_response = MagicMock(
+            return_value=_StubAsyncIter([_assistant_message("   \n\t  ")])
+        )
+
+        with patch(
+            "services.ai_service.ClaudeSDKClient",
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=mock_client),
+                __aexit__=AsyncMock(return_value=False),
+            ),
+        ):
+            with pytest.raises(InlineEditEmptyResultError):
+                await svc.quick_rewrite("sys", "usr")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_timeout(self):
+        svc = _make_service()
+
+        async def _slow_iter():
+            await asyncio.sleep(0.5)
+            yield _assistant_message("never")
+            return
+
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_client.receive_response = MagicMock(return_value=_slow_iter())
+
+        with patch(
+            "services.ai_service.ClaudeSDKClient",
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=mock_client),
+                __aexit__=AsyncMock(return_value=False),
+            ),
+        ):
+            with pytest.raises(InlineEditTimeoutError):
+                await svc.quick_rewrite("sys", "usr", timeout_s=0.1)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_disabled(self):
+        svc = _make_service(enabled=False)
+        with pytest.raises(RuntimeError):
+            await svc.quick_rewrite("sys", "usr")
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_text_blocks(self):
+        svc = _make_service()
+
+        text_block = MagicMock(spec=TextBlock)
+        text_block.text = "kept"
+        other_block = MagicMock()
+        other_block.text = None  # simulate non-text / empty block
+        msg = MagicMock(spec=AssistantMessage)
+        msg.content = [text_block, other_block]
+
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_client.receive_response = MagicMock(return_value=_StubAsyncIter([msg]))
+
+        with patch(
+            "services.ai_service.ClaudeSDKClient",
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=mock_client),
+                __aexit__=AsyncMock(return_value=False),
+            ),
+        ):
+            result = await svc.quick_rewrite("sys", "usr")
+
+        assert result == "kept"
+
+
+# ---------------------------------------------------------------------------
+# _build_quick_rewrite_options
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQuickRewriteOptions:
+    def test_disables_tools(self):
+        svc = _make_service()
+        opts = svc._build_quick_rewrite_options("system prompt")
+        assert opts.allowed_tools == []
+        assert opts.include_partial_messages is False
+        assert opts.system_prompt == "system prompt"
+        assert opts.model == "test-model"
+
+    def test_raises_when_disabled(self):
+        svc = _make_service(enabled=False)
+        with pytest.raises(RuntimeError):
+            svc._build_quick_rewrite_options("system prompt")

--- a/tests/test_ai_quick_rewrite.py
+++ b/tests/test_ai_quick_rewrite.py
@@ -4,6 +4,13 @@ Unit tests for ``AIService.quick_rewrite``.
 
 The Claude Agent SDK is mocked at the ``ClaudeSDKClient`` boundary so the
 tests don't hit the network and don't depend on a real LLM.
+
+These tests are written as plain sync functions that drive an async coroutine
+via ``asyncio.run(...)``.  The project pins ``pytest==7.4.3`` and does not
+depend on ``pytest-asyncio``; using ``@pytest.mark.asyncio`` would require
+adding a new test-time dependency just to satisfy pytest's strict-markers
+check.  See the route-level tests in ``test_inline_edit_api.py`` for the
+end-to-end behavior; the tests here cover ``quick_rewrite`` directly.
 """
 
 import asyncio
@@ -65,105 +72,69 @@ def _make_service(enabled: bool = True) -> AIService:
     return svc
 
 
+def _patch_client(svc, receive_iter):
+    """Patch ``ClaudeSDKClient`` so ``svc.quick_rewrite`` sees a fake client.
+
+    Returns the ``_patcher`` context manager so the caller can use it via
+    ``with _patch_client(...) as ...`` to keep mocking scoped to the test.
+    """
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.receive_response = MagicMock(return_value=receive_iter)
+    return patch(
+        "services.ai_service.ClaudeSDKClient",
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_client),
+            __aexit__=AsyncMock(return_value=False),
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # quick_rewrite
 # ---------------------------------------------------------------------------
 
 
 class TestQuickRewrite:
-    @pytest.mark.asyncio
-    async def test_returns_aggregated_text(self):
+    def test_returns_aggregated_text(self):
         svc = _make_service()
-
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
-        mock_client.receive_response = MagicMock(
-            return_value=_StubAsyncIter(
-                [_assistant_message("hello "), _assistant_message("world")]
-            )
-        )
-
-        with patch(
-            "services.ai_service.ClaudeSDKClient",
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_client),
-                __aexit__=AsyncMock(return_value=False),
-            ),
+        with _patch_client(
+            svc,
+            _StubAsyncIter([_assistant_message("hello "), _assistant_message("world")]),
         ):
-            result = await svc.quick_rewrite("sys", "usr")
+            result = asyncio.run(svc.quick_rewrite("sys", "usr"))
 
         assert result == "hello world"
-        mock_client.query.assert_awaited_once_with("usr")
 
-    @pytest.mark.asyncio
-    async def test_raises_on_empty_result(self):
+    def test_raises_on_empty_result(self):
         svc = _make_service()
-
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
-        mock_client.receive_response = MagicMock(return_value=_StubAsyncIter([]))
-
-        with patch(
-            "services.ai_service.ClaudeSDKClient",
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_client),
-                __aexit__=AsyncMock(return_value=False),
-            ),
-        ):
+        with _patch_client(svc, _StubAsyncIter([])):
             with pytest.raises(InlineEditEmptyResultError):
-                await svc.quick_rewrite("sys", "usr")
+                asyncio.run(svc.quick_rewrite("sys", "usr"))
 
-    @pytest.mark.asyncio
-    async def test_raises_on_whitespace_only_result(self):
+    def test_raises_on_whitespace_only_result(self):
         svc = _make_service()
-
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
-        mock_client.receive_response = MagicMock(
-            return_value=_StubAsyncIter([_assistant_message("   \n\t  ")])
-        )
-
-        with patch(
-            "services.ai_service.ClaudeSDKClient",
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_client),
-                __aexit__=AsyncMock(return_value=False),
-            ),
-        ):
+        with _patch_client(svc, _StubAsyncIter([_assistant_message("   \n\t  ")])):
             with pytest.raises(InlineEditEmptyResultError):
-                await svc.quick_rewrite("sys", "usr")
+                asyncio.run(svc.quick_rewrite("sys", "usr"))
 
-    @pytest.mark.asyncio
-    async def test_raises_on_timeout(self):
+    def test_raises_on_timeout(self):
         svc = _make_service()
 
         async def _slow_iter():
             await asyncio.sleep(0.5)
             yield _assistant_message("never")
-            return
 
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
-        mock_client.receive_response = MagicMock(return_value=_slow_iter())
-
-        with patch(
-            "services.ai_service.ClaudeSDKClient",
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_client),
-                __aexit__=AsyncMock(return_value=False),
-            ),
-        ):
+        with _patch_client(svc, _slow_iter()):
             with pytest.raises(InlineEditTimeoutError):
-                await svc.quick_rewrite("sys", "usr", timeout_s=0.1)
+                asyncio.run(svc.quick_rewrite("sys", "usr", timeout_s=0.1))
 
-    @pytest.mark.asyncio
-    async def test_raises_when_disabled(self):
+    def test_raises_when_disabled(self):
         svc = _make_service(enabled=False)
         with pytest.raises(RuntimeError):
-            await svc.quick_rewrite("sys", "usr")
+            asyncio.run(svc.quick_rewrite("sys", "usr"))
 
-    @pytest.mark.asyncio
-    async def test_ignores_non_text_blocks(self):
+    def test_ignores_non_text_blocks(self):
         svc = _make_service()
 
         text_block = MagicMock(spec=TextBlock)
@@ -173,18 +144,8 @@ class TestQuickRewrite:
         msg = MagicMock(spec=AssistantMessage)
         msg.content = [text_block, other_block]
 
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
-        mock_client.receive_response = MagicMock(return_value=_StubAsyncIter([msg]))
-
-        with patch(
-            "services.ai_service.ClaudeSDKClient",
-            return_value=MagicMock(
-                __aenter__=AsyncMock(return_value=mock_client),
-                __aexit__=AsyncMock(return_value=False),
-            ),
-        ):
-            result = await svc.quick_rewrite("sys", "usr")
+        with _patch_client(svc, _StubAsyncIter([msg])):
+            result = asyncio.run(svc.quick_rewrite("sys", "usr"))
 
         assert result == "kept"
 

--- a/tests/test_inline_edit_api.py
+++ b/tests/test_inline_edit_api.py
@@ -6,7 +6,7 @@ Tests for the inline-edit API endpoint and its post-processing helpers.
 import json
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from flask import Flask
 
@@ -185,7 +185,7 @@ class TestInlineEditEndpoint:
         ai = MagicMock()
         ai.enabled = True
         ai.model_name = "test-model"
-        ai.quick_rewrite = MagicMock(side_effect=InlineEditEmptyResultError("empty"))
+        ai.quick_rewrite = AsyncMock(side_effect=InlineEditEmptyResultError("empty"))
         app = _make_app(ai)
         client = app.test_client()
         resp = client.post(
@@ -199,7 +199,7 @@ class TestInlineEditEndpoint:
         ai = MagicMock()
         ai.enabled = True
         ai.model_name = "test-model"
-        ai.quick_rewrite = MagicMock(side_effect=InlineEditTimeoutError("timed out"))
+        ai.quick_rewrite = AsyncMock(side_effect=InlineEditTimeoutError("timed out"))
         app = _make_app(ai)
         client = app.test_client()
         resp = client.post(
@@ -284,7 +284,7 @@ class TestInlineEditEndpoint:
         ai = MagicMock()
         ai.enabled = True
         ai.model_name = "test-model"
-        ai.quick_rewrite = MagicMock(
+        ai.quick_rewrite = AsyncMock(
             side_effect=RuntimeError("internal stack trace from SDK")
         )
         app = _make_app(ai)
@@ -303,7 +303,7 @@ class TestInlineEditEndpoint:
         ai = MagicMock()
         ai.enabled = True
         ai.model_name = "test-model"
-        ai.quick_rewrite = MagicMock(side_effect=ValueError("leaky internal detail"))
+        ai.quick_rewrite = AsyncMock(side_effect=ValueError("leaky internal detail"))
         app = _make_app(ai)
         client = app.test_client()
         resp = client.post(
@@ -344,10 +344,10 @@ class TestInlineEditEndpoint:
 
 
 class _FakeAIService:
-    """Synchronous fake of the async quick_rewrite contract for the route.
+    """Async fake of the ``AIService.quick_rewrite`` contract for the route.
 
     The route calls ``anyio.run(ai_service.quick_rewrite, ...)`` so the fake
-    must be a sync callable that returns the revised text directly.
+    must be an async coroutine function that returns the revised text.
     """
 
     def __init__(self, revised: str = "ok"):
@@ -355,7 +355,7 @@ class _FakeAIService:
         self.enabled = True
         self.model_name = "fake-model"
 
-    def quick_rewrite(
+    async def quick_rewrite(
         self, system_prompt: str, user_prompt: str
     ) -> str:  # noqa: ARG002
         return self.revised

--- a/tests/test_inline_edit_api.py
+++ b/tests/test_inline_edit_api.py
@@ -240,6 +240,103 @@ class TestInlineEditEndpoint:
         assert "```" not in body["revised_text"]
         assert "## Heading" in body["revised_text"]
 
+    # ---- security: per-field size caps ---------------------------------
+
+    def test_400_when_selected_text_too_long(self):
+        app = _make_app(_FakeAIService(revised="ok"))
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x" * 5001, "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_400_when_instruction_too_long(self):
+        app = _make_app(_FakeAIService(revised="ok"))
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y" * 1001}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_400_when_context_too_long(self):
+        app = _make_app(_FakeAIService(revised="ok"))
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps(
+                {
+                    "selected_text": "x",
+                    "instruction": "y",
+                    "context_before": "a" * 1001,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    # ---- security: error message hygiene ------------------------------
+
+    def test_500_uses_generic_message_on_runtime_error(self):
+        ai = MagicMock()
+        ai.enabled = True
+        ai.model_name = "test-model"
+        ai.quick_rewrite = MagicMock(
+            side_effect=RuntimeError("internal stack trace from SDK")
+        )
+        app = _make_app(ai)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 500
+        body = resp.get_json()
+        assert "stack trace" not in body["message"]
+        assert "SDK" not in body["message"]
+
+    def test_500_uses_generic_message_on_unexpected_error(self):
+        ai = MagicMock()
+        ai.enabled = True
+        ai.model_name = "test-model"
+        ai.quick_rewrite = MagicMock(side_effect=ValueError("leaky internal detail"))
+        app = _make_app(ai)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 500
+        body = resp.get_json()
+        assert "leaky" not in body["message"]
+
+    # ---- security: dangerous response payload -------------------------
+
+    def test_500_when_response_contains_script_tag(self):
+        app = _make_app(_FakeAIService(revised="polished <script>alert(1)</script>"))
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 500
+
+    def test_500_when_response_contains_javascript_url(self):
+        app = _make_app(_FakeAIService(revised="see [link](javascript:alert(1))"))
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 500
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_inline_edit_api.py
+++ b/tests/test_inline_edit_api.py
@@ -1,0 +1,264 @@
+# coding: utf-8
+"""
+Tests for the inline-edit API endpoint and its post-processing helpers.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from routes.inline_edit_routes import (
+    _looks_like_markdown,
+    _post_process,
+    _unwrap_single_fence,
+    register_inline_edit_routes,
+)
+from services.ai_service import InlineEditEmptyResultError, InlineEditTimeoutError
+
+# ---------------------------------------------------------------------------
+# Post-processing helper tests (pure functions, no Flask)
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapSingleFence:
+    def test_unwraps_markdown_fence(self):
+        raw = "```markdown\n# Title\n\nBody.\n```"
+        out, fired = _unwrap_single_fence(raw)
+        assert fired is True
+        assert "# Title" in out
+        assert "```" not in out
+
+    def test_unwraps_plain_fence(self):
+        raw = "```\nhello world\n```"
+        out, fired = _unwrap_single_fence(raw)
+        assert fired is True
+        assert out == "hello world"
+
+    def test_no_change_when_not_fenced(self):
+        out, fired = _unwrap_single_fence("plain text")
+        assert fired is False
+        assert out == "plain text"
+
+    def test_no_change_when_fence_has_inner_fence(self):
+        raw = "```\n```python\nx = 1\n```\n```"
+        out, fired = _unwrap_single_fence(raw)
+        assert fired is False
+        assert out == raw
+
+    def test_no_change_when_fence_not_closed(self):
+        raw = "```markdown\n# Title"
+        out, fired = _unwrap_single_fence(raw)
+        assert fired is False
+
+
+class TestPostProcess:
+    def test_unwrap_then_no_strip(self):
+        raw = "```markdown\n# Title\n```"
+        out, reasons = _post_process(raw)
+        assert "unwrapped_single_fence" in reasons
+        assert "# Title" in out
+
+    def test_no_reasons_on_pure_markdown(self):
+        raw = "## Heading\n\nBody."
+        out, reasons = _post_process(raw)
+        assert reasons == []
+
+    def test_keeps_plain_prose(self):
+        # Chinese plain-prose responses must NOT be stripped — the inline-edit
+        # result is allowed to be plain prose, and stripping the first line
+        # would discard the model's actual answer.
+        raw = "为什么选择 MiniMax M3？M3 的智能水平不逊于 GLM-5.1。"
+        out, reasons = _post_process(raw)
+        assert reasons == []
+        assert out == raw
+
+
+class TestLooksLikeMarkdown:
+    def test_heading(self):
+        assert _looks_like_markdown("# heading")
+        assert _looks_like_markdown("## heading")
+
+    def test_list(self):
+        assert _looks_like_markdown("- item")
+        assert _looks_like_markdown("* item")
+        assert _looks_like_markdown("1. item")
+
+    def test_blockquote(self):
+        assert _looks_like_markdown("> quote")
+
+    def test_code(self):
+        assert _looks_like_markdown("`code`")
+
+    def test_bold(self):
+        assert _looks_like_markdown("**bold**")
+
+    def test_link(self):
+        assert _looks_like_markdown("[text](url)")
+
+    def test_plain_text_not_markdown(self):
+        assert not _looks_like_markdown("好的，这是改写后的版本")
+        assert not _looks_like_markdown("Here is the rewrite:")
+
+    def test_blank_line_is_markdown_neutral(self):
+        assert _looks_like_markdown("")
+        assert _looks_like_markdown("   ")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests (Flask test client + mocked AI service)
+# ---------------------------------------------------------------------------
+
+
+def _make_app(ai_service):
+    """Build a Flask app with the inline-edit blueprint and a fake AI service."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    bp = register_inline_edit_routes(lambda: ai_service)
+    app.register_blueprint(bp)
+    return app
+
+
+class TestInlineEditEndpoint:
+    def test_400_when_selected_text_missing(self):
+        app = _make_app(_FakeAIService(revised="ok"))
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"instruction": "polish"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["success"] is False
+
+    def test_400_when_instruction_missing(self):
+        app = _make_app(_FakeAIService(revised="ok"))
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "hello"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_503_when_ai_disabled(self):
+        disabled = MagicMock()
+        disabled.enabled = False
+        app = _make_app(disabled)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 503
+        assert "not configured" in resp.get_json()["message"].lower()
+
+    def test_200_on_success(self):
+        ai = _FakeAIService(revised="revised text")
+        app = _make_app(ai)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps(
+                {
+                    "selected_text": "hello",
+                    "instruction": "polish",
+                    "context_before": "before",
+                    "context_after": "after",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["success"] is True
+        assert body["revised_text"] == "revised text"
+        assert "model" in body
+
+    def test_500_on_empty_result(self):
+        ai = MagicMock()
+        ai.enabled = True
+        ai.model_name = "test-model"
+        ai.quick_rewrite = MagicMock(side_effect=InlineEditEmptyResultError("empty"))
+        app = _make_app(ai)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 500
+
+    def test_504_on_timeout(self):
+        ai = MagicMock()
+        ai.enabled = True
+        ai.model_name = "test-model"
+        ai.quick_rewrite = MagicMock(side_effect=InlineEditTimeoutError("timed out"))
+        app = _make_app(ai)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 504
+
+    def test_post_process_keeps_plain_prose(self):
+        # The pre-strip heuristic used to drop the first "non-Markdown" line,
+        # which is unsafe for plain-prose selections (Chinese sentences
+        # without any markdown marker). Plain prose must be returned as-is.
+        ai = _FakeAIService(revised="好的，这是改写：\n这是真正的内容。")
+        app = _make_app(ai)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "好的" in body["revised_text"]
+        assert "这是真正的内容" in body["revised_text"]
+
+    def test_post_process_unwraps_single_fence(self):
+        ai = _FakeAIService(revised="```markdown\n## Heading\n\nbody\n```")
+        app = _make_app(ai)
+        client = app.test_client()
+        resp = client.post(
+            "/api/ai/inline-edit",
+            data=json.dumps({"selected_text": "x", "instruction": "y"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "```" not in body["revised_text"]
+        assert "## Heading" in body["revised_text"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeAIService:
+    """Synchronous fake of the async quick_rewrite contract for the route.
+
+    The route calls ``anyio.run(ai_service.quick_rewrite, ...)`` so the fake
+    must be a sync callable that returns the revised text directly.
+    """
+
+    def __init__(self, revised: str = "ok"):
+        self.revised = revised
+        self.enabled = True
+        self.model_name = "fake-model"
+
+    def quick_rewrite(
+        self, system_prompt: str, user_prompt: str
+    ) -> str:  # noqa: ARG002
+        return self.revised


### PR DESCRIPTION
## What

Adds inline AI rewriting in the editor: select text → floating ✨ trigger → instruction input + 4 Chinese presets (润色 / 翻译为英文 / 精简 / 详细化) → non-streaming LLM call → original-vs-revised side-by-side diff → accept replaces the selection.

## Why

Mirrors the inline-edit feature in `latex-agent` PR #3953 — a quick, low-latency way to rewrite small fragments without leaving the editor.

## How

**Backend**
- `AIService.quick_rewrite`: non-streaming Claude Agent SDK call with `allowed_tools=[]` and a 10s `asyncio.wait_for` timeout. Returns aggregated `TextBlock` text. Two new exceptions: `InlineEditEmptyResultError`, `InlineEditTimeoutError`.
- `routes/inline_edit_routes`: `POST /api/ai/inline-edit`. Validates inputs, calls `quick_rewrite` via `anyio.run`, post-processes (single-fence unwrap only — the old "strip leading non-Markdown line" heuristic was unsafe for plain-prose selections and was the source of false "模型无输出" results), maps errors to 400/500/503/504.
- `app.py` + `routes/__init__.py`: wire the new blueprint.

**Frontend**
- `components/InlineEdit/{Overlay,Popup,Trigger,presets}`. The overlay tracks the textarea selection (debounced 300ms), shows a floating trigger near the selection end, opens a popup with the 4 presets and a free-form instruction, and calls the backend. Selection drift is caught at accept time by re-reading `textarea.value` and comparing against the snapshotted `selectedText`.
- `Editor.tsx`: mount `<InlineEditOverlay>`; new `applyInlineEdit` / `handleInlineEditDrift` handlers.

**Tests**
- `tests/test_inline_edit_api.py`: endpoint behavior (validation, 503 disabled, 200 success, 500 empty, 504 timeout) + post-processing helpers (single-fence unwrap; plain prose preserved as-is).
- `tests/test_ai_quick_rewrite.py`: `AIService.quick_rewrite` with a mocked `ClaudeSDKClient` covering empty, timeout, and success paths.

## Notes

- New dependencies: none. Uses the existing Claude Agent SDK + DeepSeek.
- A worktree-local `config_local.py` pins `HUGO_ROOT` so the dev server in `.worktrees/feat/inline-edit/` reads the user's Hugo blog (main repo's `parent.parent` resolves to the worktree collection directory, not the project).
- The OpenSpec change artifacts at `openspec/changes/add-inline-edit/` are intentionally **not** included — they were design-time scaffolding only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)