### PR TITLE
ci(review): make OpenCode PR Review manual (label-triggered)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,13 +1,23 @@
 name: OpenCode PR Review
 
+# 手动触发：仅当给 PR 添加 `ai-review` 标签时才运行（不再随 push / 打开 PR 自动触发）。
+# 重新触发：移除 `ai-review` 标签后再次添加即可。
+#
+# 为什么用标签而不是 workflow_dispatch 按钮：
+# multi-review action 通过 GITHUB_REF 中的 refs/pull/<N>/merge 来定位 PR 并回写评论，
+# 只有 pull_request 事件才会提供该上下文；若改用 workflow_dispatch（分支运行），
+# review 结果只会打印到日志、无法回写到 PR 评论。
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [labeled]
 
 jobs:
   review:
     name: AI Code Review
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event.label.name == 'ai-review' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Make the **OpenCode PR Review** workflow (`CI.yml`) manual instead of automatic. It no longer runs on every PR `opened`/`synchronize`/`reopened`/`ready_for_review`; it now runs **only when the `ai-review` label is added to a PR**.

## Why a label (not the Actions "Run workflow" button)

The `sun-praise/opencode-actions/multi-review@v3` action resolves the PR number from `GITHUB_REF` (`refs/pull/<N>/merge`) — a context that **only a `pull_request` event provides**. A `workflow_dispatch` run on a branch has no PR context, so the review would only print to the log and **never post a comment to the PR**. The label trigger keeps the `pull_request` context, so review behavior (incl. posting the comment) is identical to before — just on demand.

## How to use

- **Run a review:** add the `ai-review` label to a PR.
- **Re-run:** remove the `ai-review` label and add it again.

The `ai-review` label has been created on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow trigger configuration for pull request reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->