### PR TITLE
fix(editor): 修复 inline-edit 改写框第二次打开发起残留的竞态

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inline AI edit (rewrite) in the editor: select text → floating ✨ trigger → instruction input + 4 Chinese presets (润色 / 翻译为英文 / 精简 / 详细化) → non-streaming LLM call → original-vs-revised side-by-side diff → accept replaces the selection. Backed by a new `POST /api/ai/inline-edit` endpoint and `AIService.quick_rewrite` (Claude Agent SDK with tools disabled, 10s timeout).
 - Tests for the new endpoint and the `quick_rewrite` service method.
 
+### Fixed
+- Inline AI edit: cancel the pending selection-debounce timer when the popup closes, so a selection event registered while the popup was open can no longer re-arm the ✨ trigger against a stale selection after close (the "first invocation leaks into the second" residue).
+
 ## [2.2.0] - 2026-06-11
 
 ### Added

--- a/frontend/src/components/InlineEdit/Overlay.tsx
+++ b/frontend/src/components/InlineEdit/Overlay.tsx
@@ -117,6 +117,10 @@ export function InlineEditOverlay({
     const events: (keyof HTMLElementEventMap)[] = ['select', 'keyup', 'mouseup', 'focus'];
     events.forEach((e) => ta.addEventListener(e, schedule));
     return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
       events.forEach((e) => ta.removeEventListener(e, schedule));
     };
   }, [textareaRef, onSelectionChange]);

--- a/frontend/src/components/InlineEdit/Overlay.tsx
+++ b/frontend/src/components/InlineEdit/Overlay.tsx
@@ -52,14 +52,29 @@ export function InlineEditOverlay({
   const [anchor, setAnchor] = useState<Anchor | null>(null);
   const [open, setOpen] = useState(false);
   const aliveRef = useRef(true);
+  // The selection debounce timer is held in a ref so closeAll() can cancel
+  // any in-flight trigger. Without this, a selection event scheduled while
+  // the popup was open can fire its callback ~300ms *after* closeAll() has
+  // run — by then the `open` guard inside onSelectionChange is false again,
+  // so setAnchor() fires and re-arms the trigger against a stale selection
+  // (the source of the "first invocation leaks into the second" residue).
+  const timerRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
       aliveRef.current = false;
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
     };
   }, []);
 
   const closeAll = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     setOpen(false);
     setAnchor(null);
   }, []);
@@ -92,18 +107,16 @@ export function InlineEditOverlay({
   useEffect(() => {
     const ta = textareaRef.current;
     if (!ta) return;
-    let timer: number | null = null;
     const schedule = () => {
-      if (timer !== null) window.clearTimeout(timer);
-      timer = window.setTimeout(() => {
-        timer = null;
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = null;
         onSelectionChange();
       }, DEBOUNCE_MS);
     };
     const events: (keyof HTMLElementEventMap)[] = ['select', 'keyup', 'mouseup', 'focus'];
     events.forEach((e) => ta.addEventListener(e, schedule));
     return () => {
-      if (timer !== null) window.clearTimeout(timer);
       events.forEach((e) => ta.removeEventListener(e, schedule));
     };
   }, [textareaRef, onSelectionChange]);


### PR DESCRIPTION
## 问题

第二次发起 quick edit（选中文本 → ✨ → 改写）时，第一次的输入/选区内容有残留。用户报告后偶发，刷新页面可恢复，怀疑是竞态。

## 根因

\`InlineEditOverlay\` 的选区防抖 timer 是 \`useEffect\` 内的局部变量，\`closeAll()\` 无法触及。当 popup 打开期间 textarea 上触发了任何选区事件（\`select\`/\`keyup\`/\`mouseup\`/\`focus\`），它会 schedule 一个 300ms 的回调。\`onSelectionChange\` 里的 \`if (open) return\` guard 在 popup 打开时正确忽略它——但如果用户在 300ms 窗口内关闭了 popup，回调执行时 guard 已经是 false，\`setAnchor()\` 用关闭后的选区重新 arm 了 ✨ trigger，于是下一次打开 popup 携带了第一次的陈旧选区/状态。

## 修复

把 timer 提升为 \`timerRef\`（\`useRef<number | null>\`），在 \`closeAll()\` 和组件卸载时主动 \`clearTimeout\`，从源头切断 pending 触发。

- \`frontend/src/components/InlineEdit/Overlay.tsx\`
- \`CHANGELOG.md\`

## 验证

headless 浏览器对照测试（同一竞态脚本：popup 打开时改选区 → 立即 Escape 关闭 → 等 300ms 防抖窗口过去）：

| 版本 | 关闭后陈旧 trigger 是否残留 |
|---|---|
| \`origin/main\`（未修复） | ✅ 残留（\`triggerExists: true\`） |
| 本 PR（修复版） | ❌ 不残留（\`triggerExists: false\`） |

正常流程回归：选区 → ✨ → 输入指令 → 发送 → 接受 → 内容替换 + 选区正确，不受影响。

## 说明

代码库有约 30 个预先存在的 lint 错误（Dashboard/Server/Plugins/Posts/Editor 等，以及 Overlay 渲染期读 \`textareaRef\` 的 react-hooks/refs 规则），均非本 PR 引入，不在本次范围内。Overlay.tsx 在本 PR 前后 lint 错误数一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the inline AI edit popup could incorrectly re-enable the ✨ trigger after being closed and reopened quickly.
  * Ensured any pending selection-related debounce is cancelled when the popup closes, preventing stale selection events from affecting subsequent openings.
* **Documentation**
  * Updated the Unreleased changelog entry to reflect the inline AI edit popup fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->