### PR TITLE
fix(lint): drop unused catch bindings in editor pages

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -62,7 +62,7 @@ export default function Dashboard() {
       } else {
         showNotification('创建失败: ' + (data.message || ''), 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('创建失败', 'error');
     }
   }
@@ -87,7 +87,7 @@ export default function Dashboard() {
       } else {
         showNotification('发布失败: ' + result.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('系统发布失败', 'error');
     } finally {
       setPublishing(false);
@@ -115,7 +115,7 @@ export default function Dashboard() {
       } else {
         showNotification('推送失败: ' + result.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('邮件推送失败', 'error');
     } finally {
       setPushingEmail(false);
@@ -147,7 +147,7 @@ export default function Dashboard() {
       } else {
         showNotification('推送失败: ' + result.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('邮件推送失败', 'error');
     } finally {
       setPushingEmail(false);

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -311,7 +311,7 @@ export default function Editor() {
           showNotification('加载文件失败', 'error');
         }
       }
-    } catch (error) {
+    } catch {
       showNotification('加载文件失败', 'error');
     } finally {
       setLoading(false);
@@ -337,7 +337,7 @@ export default function Editor() {
       } else {
         showNotification('保存失败: ' + data.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('保存失败', 'error');
     } finally {
       setSaving(false);
@@ -364,7 +364,7 @@ export default function Editor() {
       } else {
         showNotification('发布失败: ' + data.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('发布失败', 'error');
     } finally {
       setPublishing(false);
@@ -408,7 +408,7 @@ export default function Editor() {
       } else {
         showNotification('上传失败: ' + data.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('上传失败', 'error');
     }
   }
@@ -434,7 +434,7 @@ export default function Editor() {
       } else {
         showNotification('生成失败: ' + (data.message || '未知错误'), 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('生成封面失败', 'error');
     } finally {
       setGeneratingCover(false);

--- a/frontend/src/pages/Posts.tsx
+++ b/frontend/src/pages/Posts.tsx
@@ -98,7 +98,7 @@ export default function Posts() {
       await post('/api/cache/refresh');
       await loadPosts();
       showNotification('缓存刷新成功', 'success');
-    } catch (error) {
+    } catch {
       showNotification('刷新失败', 'error');
     } finally {
       setRefreshing(false);
@@ -116,7 +116,7 @@ export default function Posts() {
       } else {
         showNotification('创建失败: ' + (data.message || ''), 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('创建失败', 'error');
     }
   }
@@ -181,7 +181,7 @@ export default function Posts() {
       } else {
         showNotification('导入失败: ' + (data.message || ''), 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('导入失败', 'error');
     } finally {
       setImporting(false);
@@ -221,7 +221,7 @@ export default function Posts() {
       } else {
         showNotification('批量发布失败: ' + result.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('批量发布失败', 'error');
     } finally {
       setBulkPublishing(false);

--- a/frontend/src/pages/Server.tsx
+++ b/frontend/src/pages/Server.tsx
@@ -76,7 +76,7 @@ export default function ServerPage() {
       } else {
         showNotification('启动失败: ' + data.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('启动失败', 'error');
     } finally {
       setLoading(false);
@@ -93,7 +93,7 @@ export default function ServerPage() {
       } else {
         showNotification('停止失败: ' + data.message, 'error');
       }
-    } catch (error) {
+    } catch {
       showNotification('停止失败', 'error');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

Drops the unused `error` binding from catch blocks across the four editor/admin pages. The variable was never referenced inside the catch body, so this switches to ES2019 optional catch binding (`catch {`). Zero behavior change.

## Sites changed (15 total)

**`frontend/src/pages/Dashboard.tsx`** — 4 sites
- L65 `createNewPost`
- L90 `publishSystem`
- L118 `pushLatestEmail`
- L150 `pushSpecificEmail`

**`frontend/src/pages/Editor.tsx`** — 5 sites
- L314 `loadFile`
- L340 `saveFile`
- L367 `publishArticle`
- L411 `uploadImage`
- L437 `generateCoverImage`

**`frontend/src/pages/Posts.tsx`** — 4 sites
- L101 `refreshCache`
- L119 `createNewPost`
- L184 `handleFilePicked`
- L224 `bulkPublish`

**`frontend/src/pages/Server.tsx`** — 2 sites
- L79 `startServer`
- L96 `stopServer`

Catches that DO reference `error` (e.g. `console.error('…', error)` in `loadStats` / `loadRecentPosts` / `loadServerStatus` / `loadFilters` / `loadPosts` / `checkPublishStatus` / `loadImages` / `generateFrontmatterFromAI` / `loadBacklinks` / `loadRefSearchResults` / `fetchStatus` / `fetchHugoUrl`) were deliberately left untouched — the binding is still required there.

## Out of scope

The remaining lint findings in these four files are B-class and will be addressed separately:
- `react-hooks/immutability` (Dashboard: loadStats/loadRecentPosts/loadServerStatus accessed before declared; Server: fetchStatus/fetchHugoUrl accessed before declared)
- `react-hooks/set-state-in-effect` (Posts:67, the `useEffect(() => { loadPosts(); loadFilters(); }, [loadPosts])` pattern)
- `react-hooks/exhaustive-deps` (Editor:84,88)
- Plus pre-existing findings in unrelated files (Overlay.tsx refs, PageTitleContext.tsx, Plugins.tsx, utils/api.ts preserve-caught-error).

Suppression (`eslint-disable`) was deliberately not used — the binding was simply dropped where unused.

## Verification

`pnpm lint` — `no-unused-vars` count across the four target files: **0** (whole-project count: 0)

```
$ pnpm lint 2>&1 | grep -c no-unused-vars
0
```

Remaining problems across the project (all B-class, pre-existing, out of scope for this PR):

```
✖ 18 problems (15 errors, 3 warnings)
```

Breakdown across the four edited files (all B-class):
- `Dashboard.tsx`: 3 errors — `react-hooks/immutability`
- `Editor.tsx`: 2 warnings — `react-hooks/exhaustive-deps`
- `Posts.tsx`: 1 error — `react-hooks/set-state-in-effect` (line 67)
- `Server.tsx`: 2 errors — `react-hooks/immutability`

`pnpm run build` — succeeds:

```
> tsc -b && vite build

vite v8.0.16 building client environment for production...
transforming...
✓ 1993 modules transformed.
rendering chunks...
computing gzip size...
../static/dist/index.html                     0.52 kB │ gzip:   0.34 kB
../static/dist/assets/index-6_oN1A3w.css     38.44 kB │ gzip:   8.18 kB
../static/dist/assets/index-ST-SjMdS.js   1,362.59 kB │ gzip: 441.36 kB

✓ built in 279ms
```

(`tsc -b` clean; vite build clean; the chunk-size note is an advisory, not an error.)

## Notes

- Branch rebased onto current `origin/main` (`9042e70`) before push; no conflicts.
- No dependency changes, no runtime changes; tsconfig already targets `es2023` so optional catch binding is supported.
- Single commit; worktree left in place at `.worktrees/lint-catch-error/` until merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling patterns across multiple pages by streamlining catch blocks, enhancing code maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->