### PR TITLE
fix(lint): preserve error cause and split PageTitleContext exports

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { get } from '../utils/api';
-import { usePageTitle } from '../contexts/PageTitleContext';
+import { usePageTitle } from '../hooks/usePageTitle';
 import type { ServerStatus } from '../types';
 
 const pageTitles: Record<string, string> = {

--- a/frontend/src/contexts/PageTitleContext.tsx
+++ b/frontend/src/contexts/PageTitleContext.tsx
@@ -1,10 +1,5 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
-
-const PageTitleContext = createContext<{
-  title: string;
-  setTitle: (title: string) => void;
-  resetTitle: () => void;
-}>({ title: '', setTitle: () => {}, resetTitle: () => {} });
+import { useState, useCallback, type ReactNode } from 'react';
+import { PageTitleContext } from '../hooks/usePageTitle';
 
 export function PageTitleProvider({ children }: { children: ReactNode }) {
   const [title, setTitleState] = useState('');
@@ -16,8 +11,4 @@ export function PageTitleProvider({ children }: { children: ReactNode }) {
       {children}
     </PageTitleContext.Provider>
   );
-}
-
-export function usePageTitle() {
-  return useContext(PageTitleContext);
 }

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+export const PageTitleContext = createContext<{
+  title: string;
+  setTitle: (title: string) => void;
+  resetTitle: () => void;
+}>({ title: '', setTitle: () => {}, resetTitle: () => {} });
+
+export function usePageTitle() {
+  return useContext(PageTitleContext);
+}

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -22,7 +22,7 @@ import {
 import { get, post } from '../utils/api';
 import { renderMarkdown } from '../utils/markdown';
 import type { FileData, ImageItem, Backlink, Frontmatter } from '../types';
-import { usePageTitle } from '../contexts/PageTitleContext';
+import { usePageTitle } from '../hooks/usePageTitle';
 import { InlineEditOverlay } from '../components/InlineEdit/Overlay';
 
 export default function Editor() {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -18,7 +18,7 @@ export async function request<T>(url: string, options?: RequestInit): Promise<T>
       throw new Error(error.message || `HTTP ${response.status}`);
     } catch (e) {
       if (e instanceof Error && e.message !== `HTTP ${response.status}`) throw e;
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`, { cause: e });
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two unrelated lint findings; no behavior changes except preserving the original error in `api.ts`'s HTTP fallback.

### 1. `frontend/src/utils/api.ts` — `preserve-caught-error`

The catch block around `response.json()` was throwing a new `Error("HTTP <status>: <statusText>")` without attaching the caught error, losing the original (e.g. JSON parse) error. Now passes the caught error via `Error(... , { cause: e })`.

### 2. `frontend/src/contexts/PageTitleContext.tsx` — `react-refresh/only-export-components`

The file exported both the `PageTitleProvider` component and the `usePageTitle` hook. The react-refresh rule (which only allows component exports in component files) flagged the hook.

**Split:**
- New file `frontend/src/hooks/usePageTitle.ts` now owns the `PageTitleContext` constant **and** the `usePageTitle` hook. The rule's algorithm skips files with no component exports, so this is clean.
- `frontend/src/contexts/PageTitleContext.tsx` is left as the only place `PageTitleProvider` is exported. It imports `PageTitleContext` from the new sibling.
- `usePageTitle.ts` (not `.tsx`) deliberately has no JSX, and `react-refresh` doesn't scan `.ts` files anyway — defensive double-coverage.

### Importer files updated
- `frontend/src/components/Header.tsx` — `usePageTitle` import moved to `../hooks/usePageTitle`.
- `frontend/src/pages/Editor.tsx` — `usePageTitle` import moved to `../hooks/usePageTitle`.
- `frontend/src/components/Layout.tsx` — unchanged (still imports `PageTitleProvider` from `../contexts/PageTitleContext`).

No barrel re-export was introduced (would itself re-trigger the same rule).

### Out of scope
Many other lint errors exist across `Overlay.tsx`, `Dashboard.tsx`, `Editor.tsx`, `Plugins.tsx`, `Posts.tsx`, `Server.tsx` (refs during render, hoisted function refs in effects, unused `error` vars, etc.). They are pre-existing on `main` and explicitly out of scope for this change.

### Verification
- `pnpm lint`: **0 errors** in `PageTitleContext.tsx`, `api.ts`, `usePageTitle.ts`. The 31 remaining errors are all in unrelated files listed above.
- `pnpm run build`: succeeds. `tsc -b` is clean (validates the new import paths) and `vite build` emits bundles (~1.36 MB JS / 38 kB CSS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in API requests to preserve and surface underlying error details, improving debugging visibility when requests fail.

* **Refactor**
  * Reorganized hook module structure for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->