### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-16
+
 ### Added
 - Inline AI edit (rewrite) in the editor: select text → floating ✨ trigger → instruction input + 4 Chinese presets (润色 / 翻译为英文 / 精简 / 详细化) → non-streaming LLM call → original-vs-revised side-by-side diff → accept replaces the selection. Backed by a new `POST /api/ai/inline-edit` endpoint and `AIService.quick_rewrite` (Claude Agent SDK with tools disabled, 10s timeout).
 - Tests for the new endpoint and the `quick_rewrite` service method.
 
 ### Fixed
 - Inline AI edit: cancel the pending selection-debounce timer when the popup closes, so a selection event registered while the popup was open can no longer re-arm the ✨ trigger against a stale selection after close (the "first invocation leaks into the second" residue).
+- Prevent image paste from overwriting previous uploads on filename collision (#70)
+- Add file size limit (20 MB) and extension whitelist for image uploads
 
 ## [2.2.0] - 2026-06-11
 
@@ -56,12 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stale closure in handlePaste with functional setState
 - Blank-line accumulation between frontmatter and body
 - Move hasChanges useMemo after frontmatter declarations
-
-## [Unreleased]
-
-### Fixed
-- Prevent image paste from overwriting previous uploads on filename collision (#70)
-- Add file size limit (20 MB) and extension whitelist for image uploads
 
 ## [2.1.0] - 2026-06-04
 

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 __version_info__ = tuple(int(x) for x in __version__.split("."))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.4.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "packageManager": "pnpm@9.15.0",
   "engines": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hugo-admin"
-version = "2.2.0"
+version = "2.3.0"
 description = "A lightweight web-based admin interface for managing Hugo static sites"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

Bump project version from 2.2.0 to 2.3.0 and consolidate the changelog.

## Changes

- Bump version in `pyproject.toml`, `__version__.py`, `frontend/package.json`, and `frontend/package-lock.json` (both root version fields).
- Add `## [2.3.0] - 2026-06-16` section to `CHANGELOG.md`, consolidating the two previously-`[Unreleased]` blocks:
  - Inline AI edit (rewrite) feature + endpoint tests (Added)
  - Inline AI edit selection-debounce race fix (#112) (Fixed)
  - Image paste overwrite on collision (#70) + 20 MB size limit / extension whitelist (Fixed)
- Delete the misplaced orphan `[Unreleased]` block that sat between `[2.1.1]` and `[2.1.0]`; its content (PR #70) was never released and now lives in 2.3.0.
- Retain an empty `## [Unreleased]` header at top per Keep a Changelog.

## Tag plan

`v2.3.0` tag will be created on main **after** this merges, to avoid repeating the orphaned-`v2.2.0`-tag problem (the existing `v2.2.0` at `6f40aab` is unreachable from main; the real bump commit `0197e1d` was never tagged).

## Checklist
- [x] Version files updated and synchronized (verified no stray 2.2.0)
- [x] CHANGELOG consolidated; empty `[Unreleased]` retained
- [x] Committed in worktree under `.worktrees/` per AGENTS.md
- [x] Branch pushed from worktree