### PR TITLE
chore(release): v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [2.5.0] - 2026-06-28
 
 ### Fixed
 - Python 3.10 下 `PUT /api/config` 返回 400：`tomllib` 在 3.11 才进标准库，回退到 `tomli`/`tomllib` 可选导入以兼容 3.10。
 - 对齐版本号：此前 `__version__.py` 停留在 2.3.0，本次追平到 2.5.0，`/api/version` 不再误报。
-
-## [Unreleased]
 
 ## [2.4.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-06-28
+
+### Fixed
+- Python 3.10 下 `PUT /api/config` 返回 400：`tomllib` 在 3.11 才进标准库，回退到 `tomli`/`tomllib` 可选导入以兼容 3.10。
+- 对齐版本号：此前 `__version__.py` 停留在 2.3.0，本次追平到 2.5.0，`/api/version` 不再误报。
+
 ## [Unreleased]
 
 ## [2.4.0] - 2026-06-26

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "2.3.0"
+__version__ = "2.5.0"
 __version_info__ = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
## 发版内容

- `__version__.py`: `2.3.0` → `2.5.0`。此前 tag `v2.4.0` 发布时版本号未同步（停在 2.3.0），导致 `/api/version` 持续误报，本次追平。
- `CHANGELOG.md`: 新增 `[2.5.0]` 条目，收录自 v2.4.0 以来的修复：
  - Python 3.10 下 `PUT /api/config` 返回 400（`tomllib` 3.11+ 才进标准库，回退兼容导入）

## 鉴权说明（非本版变更，澄清）
密码登录与 API 会话守卫是 **v2.4.0** 引入的（见 CHANGELOG [2.4.0]/Added）。本版无鉴权改动。

## 合并后操作
1. 打 tag `v2.5.0` 并推送 → 触发 `docker-image.yml` 发布 `ghcr.io/sun-praise/hugo-admin:2.5.0` / `:latest`
2. jd 服务器 `docker pull` + `docker compose up -d` 升级
3. 验证 `/api/version` 报 `2.5.0`

cc @Svtter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Python 3.10 for configuration updates.
  * Corrected the application version reported by version checks so it now displays **2.5.0** accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->