### PR TITLE
fix(docker): multi-stage 构建前端，发布 v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-06-28
+
+### Fixed
+- Dockerfile 漏掉前端构建：镜像内 `static/dist/` 是仓库历史残留的旧前端，导致 RequireAuth 路由守卫未生效，未登录也能看到管理界面空壳（后端 API 鉴权始终正常，未登录无法读写任何数据）。改为 multi-stage：Stage 1 `node:22-slim` 跑 `pnpm build`，Stage 2 把产物覆盖到 `/app/static/dist`。
+- HEALTHCHECK 端点从 `/api/server/status`（需登录，未认证 401 导致容器永远 starting）改为 `/api/version`（免认证）。
+
 ## [2.5.0] - 2026-06-28
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 # Hugo Admin Dockerfile
 
+# ============ Stage 1: 前端构建 ============
+FROM node:22-slim AS frontend-build
+WORKDIR /build
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY frontend/ ./
+# vite outDir 为 ../static/dist（相对 frontend/），构建产物落到 /static/dist
+RUN pnpm run build && ls -la /static/dist
+
+# ============ Stage 2: 运行时 ============
 FROM python:3.11-slim
 
 # 设置工作目录
@@ -29,6 +40,9 @@ RUN curl -L "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}
 # 复制应用代码
 COPY . .
 
+# 用 Stage 1 构建的前端产物覆盖仓库里的陈旧 static/dist
+COPY --from=frontend-build /static/dist /app/static/dist
+
 # 安装 Python 依赖（兼容移除 requirements.txt 后的依赖管理方式）
 RUN pip install --no-cache-dir .
 
@@ -38,9 +52,9 @@ RUN mkdir -p /app/content /app/public /app/static /app/templates
 # 暴露端口
 EXPOSE 5050 1313
 
-# 健康检查
+# 健康检查：/api/version 免认证，确保 healthcheck 不会因 401 永远 starting
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:5050/api/server/status || exit 1
+    CMD curl -f http://localhost:5050/api/version || exit 1
 
 # 清理 Docker 挂载可能自动创建的 config.toml 目录（Hugo 会误读为配置文件）
 CMD ["sh", "-c", "test -d /app/config.toml && rm -rf /app/config.toml; python app.py"]

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __version_info__ = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
## 问题
线上 `/api/version` 已是 2.5.0，但打开 `hugo-admin.sun-praise.com` **未登录就能看到管理界面**（空壳）。

## 根因
`Dockerfile` 只 `COPY . .`，**没有前端构建步骤**。而 `frontend/dist` 在 `.gitignore` 里，仓库里的 `static/dist/` 是 v2.4.0 鉴权功能加入前的一次手动提交残留。结果：镜像内前端缺失 `RequireAuth` 路由守卫，UI 先渲染再被 401 赶走。

**后端鉴权始终正常**——实测未登录对 `/api/article/publish` `/api/server/start` `/api/image/upload` `/api/git/push` `/api/config` `/api/project/init` 全 401，无法读写任何数据。问题仅在前端空壳可被看到。

## 修复
1. **Dockerfile multi-stage**：Stage 1 `node:22-slim` 跑 `pnpm build`，Stage 2 `COPY --from=frontend-build /static/dist /app/static/dist` 覆盖残留产物。
2. **HEALTHCHECK 改 `/api/version`**：原 `/api/server/status` 需登录，未认证 401 导致容器永远 `starting`（部署时得手动改 compose）。
3. 版本号 `2.5.0` → `2.5.1`。

## 验证
本地 `docker build` 成功，新镜像内前端 bundle 实测含 `auth/me` / `加载中`（RequireAuth 守卫逻辑），旧镜像为 0。

## 合并后
打 `v2.5.1` tag → CI 发镜像 → jd 拉新镜像升级 → 验证未登录直接跳 /login

cc @Svtter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the app could serve stale frontend assets, causing authentication guards to behave inconsistently.
  * Updated container health checks to use an endpoint that doesn’t require sign-in, reducing false unhealthy/starting states.
* **Chores**
  * Bumped the app version to **2.5.1**.
  * Recorded the latest fixes in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->