### PR TITLE
fix(docker): admin 前端搬到 /app/admin-ui，根治挂载冲突

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY frontend/ ./
-# vite outDir 为 ../static/dist（相对 frontend/），构建产物落到 /static/dist
-RUN pnpm run build && ls -la /static/dist
+# vite outDir 为 ../admin-ui（相对 frontend/），构建产物落到 /admin-ui
+RUN pnpm run build && ls -la /admin-ui
 
 # ============ Stage 2: 运行时 ============
 FROM python:3.11-slim
@@ -40,8 +40,8 @@ RUN curl -L "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}
 # 复制应用代码
 COPY . .
 
-# 用 Stage 1 构建的前端产物覆盖仓库里的陈旧 static/dist
-COPY --from=frontend-build /static/dist /app/static/dist
+# 用 Stage 1 构建的前端产物覆盖到 /app/admin-ui（避开博客 static 挂载点）
+COPY --from=frontend-build /admin-ui /app/admin-ui
 
 # 安装 Python 依赖（兼容移除 requirements.txt 后的依赖管理方式）
 RUN pip install --no-cache-dir .

--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ app = Flask(__name__)
 
 
 # React SPA 的 index.html 路径
-REACT_INDEX = Path(__file__).parent / "static" / "dist" / "index.html"
+REACT_INDEX = Path(__file__).parent / "admin-ui" / "index.html"
 
 # 配置日志 - 写入 app.log，带轮转
 logger = logging.getLogger(__name__)
@@ -266,7 +266,7 @@ def not_found(e):
     """404 错误处理 - SPA fallback"""
     if request.path.startswith("/api/"):
         return jsonify({"success": False, "message": "接口不存在"}), 404
-    if request.path.startswith("/static/dist/"):
+    if request.path.startswith("/admin-ui/"):
         return jsonify({"success": False, "message": "静态文件不存在"}), 404
     return send_file(current_app.config["REACT_INDEX"])
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,9 +5,9 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: '/static/dist/',
+  base: '/admin-ui/',
   build: {
-    outDir: '../static/dist',
+    outDir: '../admin-ui',
     emptyOutDir: true,
   },
 })

--- a/tests/test_spa_routes.py
+++ b/tests/test_spa_routes.py
@@ -110,8 +110,8 @@ class TestSPARoutes:
     # -- Static dist 404 returns JSON, not SPA --
 
     def test_static_dist_404_returns_json(self, client):
-        """Missing static/dist files should return JSON, not SPA."""
-        resp = client.get("/static/dist/missing.js")
+        """Missing /admin-ui/* files should return JSON, not SPA."""
+        resp = client.get("/admin-ui/missing.js")
         assert resp.status_code == 404
         data = json.loads(resp.data)
         assert data["success"] is False


### PR DESCRIPTION
## 问题
镜像前端在 `/app/static/dist/`，但 docker-compose 把博客 `${HUGO_BLOG_DIR}/static` 挂到 `/app/static` —— **bind mount 整个遮蔽了镜像的前端目录**。

后果（v2.5.1 部署实测）：
- 首页 500（`REACT_INDEX` 找不到）
- 或镜像前端被博客里的陈旧 dist 覆盖（之前临时 docker cp 前端到 hugo-blog/static/dist 凑出来的，污染了博客目录）
- 之前 demo 部署时，blog/static 一挂载就把 admin 前端干掉

## 修复
admin 前端搬到独立路径 `/app/admin-ui`，与博客 static 物理隔离：

| 文件 | 改动 |
|---|---|
| `Dockerfile` | Stage 1 build + Stage 2 COPY 都指向 `/app/admin-ui` |
| `app.py` | `REACT_INDEX` → `/app/admin-ui/index.html`；404 handler 前缀判断 `/admin-ui/` |
| `frontend/vite.config.ts` | `base: '/admin-ui/'`，`outDir: '../admin-ui'` |
| `tests/test_spa_routes.py` | 静态 404 测试路径同步改 `/admin-ui/missing.js` |

## 验证（本地 docker 模拟生产挂载）
```bash
# 挂假博客 static 到 /app/static
docker run -v /tmp/fake-static:/app/static ...
```
- `/app/admin-ui/` 完整存在（不被挂载影响）✓
- 首页 HTTP 200（不再 500）✓
- 前端 bundle 走 `/admin-ui/assets/index-BcKTajuk.js` ✓
- `/api/version` 200 ✓

## 部署兼容性
- compose 不用改（`${BLOG}/static:/app/static` 保持，给 Hugo 用）
- 升级路径：拉新镜像即可，老挂载不再冲突

cc @Svtter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the admin interface to load from a new web path, keeping the app accessible after deployment changes.
  * Improved error handling for missing admin UI assets so invalid asset requests return a clear JSON 404 response.
  * Preserved single-page app fallback behavior for normal navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->