### PR TITLE
chore(version): 追平 2.5.2 + CI 校验 tag/版本号一致

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,26 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # tag push 时校验 __version__.py 与 tag 一致，防止版本号漏改
+  verify-version:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check __version__.py matches tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          file_ver=$(grep -oE '__version__ = "[0-9.]+"' __version__.py | grep -oE '[0-9.]+')
+          echo "tag version: $tag"
+          echo "__version__.py: $file_ver"
+          if [ "$tag" != "$file_ver" ]; then
+            echo "::error::__version__.py ($file_ver) 与 tag ($tag) 不一致，请同步版本号"
+            exit 1
+          fi
+
   build-and-push:
+    needs: verify-version
+    if: always() && (needs.verify-version.result == 'skipped' || needs.verify-version.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.2] - 2026-06-28
+
+### Fixed
+- 版本号追平：`__version__.py` 此前停在 2.5.1（v2.5.2 tag 发版时漏改），追平到 2.5.2，`/api/version` 不再误报。
+- admin 前端从 `/app/static/dist` 搬到 `/app/admin-ui`，根治与博客 `static` 挂载的 bind mount 冲突（见 #125）。
+
+
 ### Added
 - 编辑器预览支持渲染 mermaid 图表：`renderMarkdown` 新增 opt-in `{ mermaid }` 选项，开启时在 marked 解析前抽出 ` ```mermaid ` 围栏块还原为 `.mermaid` 容器；Editor 预览懒加载 mermaid（dynamic import，按需加载，失败可重试）并 `api.run()` 渲染，输入变更 200ms debounce 后重渲。`securityLevel: strict`，不绕过 DOMPurify。AIChat 等未开启的调用方行为不变。
 

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 __version_info__ = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
## 问题
v2.4.0、v2.5.2 两次发版都出现 `__version__.py` 漏改的情况，导致 `/api/version` 持续误报旧版本号。这是个反复出现的发版流程缺陷。

## 修复
1. **`__version__.py` 2.5.1 → 2.5.2**：追平已发布的 tag，`/api/version` 立即正确
2. **`docker-image.yml` 加 `verify-version` job**：tag push 时校验 `__version__.py` 与 tag 必须一致，不一致则 CI 失败
   - `build-and-push` 依赖 `verify-version`（`needs`），校验失败不构建
   - 仅 tag push 触发（`if: startsWith(github.ref, 'refs/tags/v')`），main/PR 不影响
3. **CHANGELOG 补 [2.5.2] 条目**

## 校验逻辑
```bash
tag="${GITHUB_REF_NAME#v}"   # v2.5.2 -> 2.5.2
file_ver=$(grep -oE '__version__ = "[0-9.]+"' __version__.py | grep -oE '[0-9.]+')
[ "$tag" = "$file_ver" ] || exit 1
```

以后任何人打 tag 忘了改版本号，CI 会立刻报错。

cc @Svtter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version reporting so the app’s reported version matches the released tag.
  * Resolved an admin UI deployment conflict by moving it to a separate path.
* **Chores**
  * Updated the app version to **2.5.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->