### PR TITLE
chore(release): v2.5.3 追平版本号

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.3] - 2026-06-28
+
+### Fixed
+- 版本号追平：v2.5.2 tag 发版时 `__version__.py` 仍是 2.5.1（PR #126 才补改到 2.5.2），本次追平到 2.5.3，`/api/version` 不再误报。
+
+
 ## [2.5.2] - 2026-06-28
 
 ### Fixed

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "2.5.2"
+__version__ = "2.5.3"
 __version_info__ = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
## 内容
- `__version__.py` 2.5.2 → 2.5.3，追平将打的 tag
- CHANGELOG 补 [2.5.3] 条目

## 背景
v2.5.2 tag 发版时 `__version__.py` 还是 2.5.1（PR #126 才补改到 2.5.2，但 v2.5.2 tag 已发，只能发新版追平）。这次合并后打 `v2.5.3` tag，新加的 `verify-version` CI 会校验一致。

cc @Svtter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a version mismatch so the app now reports the correct release version in the version endpoint.
* **Changelog**
  * Added a new 2.5.3 release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->