### PR TITLE
fix(admin-ui): 修复 run.sh 启动后管理界面白屏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 管理界面白屏：PR #125 把前端产物从 `static/dist/` 搬到 `admin-ui/`（解决 Docker 下与博客 `static` 挂载冲突）后，漏了给 Flask 注册 `/admin-ui/` 静态路由，`index.html` 引用的 `/admin-ui/assets/*` 全部 404、React 不渲染。改为 `Flask(__name__, static_folder="admin-ui", static_url_path="/admin-ui")`，由原生 static 路由统一 serve；缺失文件仍 404 经 `not_found()` 返回 JSON。
+
 ## [2.5.3] - 2026-06-28
 
 ### Fixed
@@ -18,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - 版本号追平：`__version__.py` 此前停在 2.5.1（v2.5.2 tag 发版时漏改），追平到 2.5.2，`/api/version` 不再误报。
 - admin 前端从 `/app/static/dist` 搬到 `/app/admin-ui`，根治与博客 `static` 挂载的 bind mount 冲突（见 #125）。
-
 
 ### Added
 - 编辑器预览支持渲染 mermaid 图表：`renderMarkdown` 新增 opt-in `{ mermaid }` 选项，开启时在 marked 解析前抽出 ` ```mermaid ` 围栏块还原为 `.mermaid` 容器；Editor 预览懒加载 mermaid（dynamic import，按需加载，失败可重试）并 `api.run()` 渲染，输入变更 200ms debounce 后重渲。`securityLevel: strict`，不绕过 DOMPurify。AIChat 等未开启的调用方行为不变。

--- a/app.py
+++ b/app.py
@@ -51,7 +51,11 @@ from services.settings_service import (
 
 # 初始化 Flask 应用
 load_dotenv()
-app = Flask(__name__)
+# 前端构建产物落在 ./admin-ui（见 frontend/vite.config.ts 的 outDir），
+# 对外 URL 前缀 /admin-ui/。用 Flask 原生 static 路由统一 serve：
+#   /admin-ui/assets/*、/admin-ui/favicon.svg … 命中真实文件 → 200 + 正确 MIME，
+#   缺失文件抛 404 → 走下方 not_found() 返回 JSON（不回退成 SPA）。
+app = Flask(__name__, static_folder="admin-ui", static_url_path="/admin-ui")
 
 
 # React SPA 的 index.html 路径

--- a/tests/test_spa_routes.py
+++ b/tests/test_spa_routes.py
@@ -116,6 +116,24 @@ class TestSPARoutes:
         data = json.loads(resp.data)
         assert data["success"] is False
 
+    def test_admin_ui_static_file_served(self, client, monkeypatch):
+        """Existing /admin-ui/* assets are served with the right MIME.
+
+        Regression for PR #125: the frontend moved to ./admin-ui but no
+        route served /admin-ui/*, so every JS/CSS asset 404 and the SPA
+        rendered blank. Flask static_folder now points at admin-ui.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            asset = Path(tmp) / "assets" / "app.js"
+            asset.parent.mkdir(parents=True)
+            asset.write_text("console.log(0);", encoding="utf-8")
+            monkeypatch.setattr(app_module.app, "static_folder", tmp)
+            resp = client.get("/admin-ui/assets/app.js")
+            # Flask may serve .js as text/javascript or application/javascript
+            # depending on version/config; accept either.
+            assert resp.mimetype in {"text/javascript", "application/javascript"}
+            assert b"console.log" in resp.data
+
     # -- Version API --
 
     def test_version_api(self, client):


### PR DESCRIPTION
PR #125 把前端产物从 `static/dist/` 搬到 `admin-ui/`（避开 Docker 下博客 `static` bind-mount 冲突），但漏了给 Flask 注册 `/admin-ui/` 静态路由：`index.html` 引用的 `/admin-ui/assets/*.js|css` 全部 404（返回 JSON），React 不渲染，5050 打开是空白页。

> 此前 #128 因分支 force-push 事故被手动关闭，本 PR 用干净分支重开，修复内容相同（合入 #128 的 CodeRabbit MIME 建议）。

## 修复
```python
app = Flask(__name__, static_folder="admin-ui", static_url_path="/admin-ui")
```
由 Flask 原生 static 路由统一 serve `/admin-ui/*`：真实文件 200 + 正确 MIME，缺失文件仍 404 经 `not_found()` 返回 JSON（行为不变，`test_static_dist_404_returns_json` 仍绿）。

## 验证
- test client 请求真实 React bundle `/admin-ui/assets/index-DhompHHb.js`（1.42MB）→ 200 `text/javascript`
- 新增回归测试 `test_admin_ui_static_file_served`（MIME 用 allowlist，兼容 `text/javascript`/`application/javascript`）
- 全量 `pytest -q`：**377 passed**；`ruff check` 干净

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed serving of Admin UI static assets after the UI build output moved, ensuring `/admin-ui/*` files resolve under the correct URL.
  - Asset requests now return the correct JavaScript MIME type, while missing `/admin-ui/` resources still produce JSON 404 responses.

- **Tests**
  - Added a regression test verifying `/admin-ui/assets/app.js` is served successfully with the expected JavaScript content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->