### PR TITLE
chore(release): v2.5.4 修复管理界面白屏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.4] - 2026-06-28
+
 ### Fixed
-- 管理界面白屏：PR #125 把前端产物从 `static/dist/` 搬到 `admin-ui/`（解决 Docker 下与博客 `static` 挂载冲突）后，漏了给 Flask 注册 `/admin-ui/` 静态路由，`index.html` 引用的 `/admin-ui/assets/*` 全部 404、React 不渲染。改为 `Flask(__name__, static_folder="admin-ui", static_url_path="/admin-ui")`，由原生 static 路由统一 serve；缺失文件仍 404 经 `not_found()` 返回 JSON。
+- 管理界面白屏（`run.sh` 启动后访问 :5050 空白）：PR #125 把前端产物从 `static/dist/` 搬到 `admin-ui/`（解决 Docker 下与博客 `static` 挂载冲突）后，漏了给 Flask 注册 `/admin-ui/` 静态路由，`index.html` 引用的 `/admin-ui/assets/*` 全部 404、React 不渲染。改为 `Flask(__name__, static_folder="admin-ui", static_url_path="/admin-ui")`，由原生 static 路由统一 serve；缺失文件仍 404 经 `not_found()` 返回 JSON。见 #129。
 
 ## [2.5.3] - 2026-06-28
 

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "2.5.3"
+__version__ = "2.5.4"
 __version_info__ = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
发版 v2.5.4，内容为 PR #129（修复管理界面白屏）。

## 改动
- `__version__.py`：2.5.3 → 2.5.4
- `CHANGELOG.md`：新增 `[2.5.4] - 2026-06-28` 段，白屏修复条目从 `[Unreleased]` 提升

## 合并后
打 tag `v2.5.4`，触发 `docker-image.yml` 的 `verify-version` 校验（`__version__.py` 需与 tag 一致）+ 构建推送镜像。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new 2.5.4 changelog entry.
  * Updated the admin interface blank-screen fix note with an additional reference.

* **Chores**
  * Bumped the app version to 2.5.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->