### PR TITLE
fix(docker): 升级镜像 hugo 0.121.1→0.163.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 镜像内 Hugo 版本过旧：Dockerfile 锁在 `0.121.1`（2023-12），跑不动现代主题——如作者自己的 Fried-Rice（`theme.toml` 要求 `min_version = 0.157.0`，用到 `hash.FNV32a` / `mod` 等 0.121 不支持的函数），admin「启动 Hugo 服务器」后 hugo 进程立即 parse fail 退出。升级到 `0.163.3`（对齐本机 dev 环境 0.163.1）。影响：jd demo 预览闭环（1313 反代到 `demo-blog.sun-praise.com`）此前 hugo server 起不来，升级后可用。
+
 ## [2.5.4] - 2026-06-28
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # 安装 Hugo Extended
-ARG HUGO_VERSION=0.121.1
+# 升级到 0.163.3：Fried-Rice 等现代主题要求 hugo >= 0.157.0（hash.FNV32a / mod
+# 等函数旧版不支持）。对齐本机 dev 环境（0.163.1），消除"本地能跑、demo 跑不动"的版本差。
+ARG HUGO_VERSION=0.163.3
 RUN curl -L "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" -o hugo.tar.gz \
     && tar -xzf hugo.tar.gz -C /usr/local/bin/ \
     && rm hugo.tar.gz \


### PR DESCRIPTION
## 问题
镜像内 Hugo 锁在 \`0.121.1\`（2023-12，两年半前），跑不动现代主题。

发现路径：jd demo 部署 hugo-admin 后，admin「Hugo 服务器」页点「启动」，hugo 进程立即退出：
\`\`\`
Error: "/app/themes/stack/layouts/_partials/helper/color-from-str.html:4:1": parse failed
WARN Module "stack" is not compatible with this Hugo version
\`\`\`

根因：Fried-Rice 主题（hugo-admin demo 默认主题，也是作者自己的博客主题）\`theme.toml\` 声明 \`min_version = "0.157.0"\`，用到 \`hash.FNV32a\` / \`mod\` 等模板函数，hugo 0.121.1 不支持 → parse fail。

## 修复
\`Dockerfile\` \`ARG HUGO_VERSION\` \`0.121.1\` → \`0.163.3\`：
- 0.163.3 是当前 hugo 最新 extended release（2026-06-18）
- 对齐本机 dev 环境（0.163.1），消除「本地能跑、容器跑不动」的版本差
- admin 对 hugo 的调用只用稳定 API（\`hugo server --bind -b --disableFastRender -D --theme\`），0.121→0.163 无破坏性变更

## 验证
- 本地 \`docker build\` 成功，hugo 0.163.3 extended 二进制安装正常
- Fried-Rice 主题 min_version 要求（0.157.0）满足

## 影响
打通 jd demo 预览闭环：admin 启动 hugo server → 容器 1313 → nginx 反代 → \`demo-blog.sun-praise.com\`。此前 hugo server 起不来，预览域名空响应。

## 关联
- jd demo 预览配置（compose + nginx）：Svtter/ops（本 PR 仅修镜像 hugo 版本）
- issue #131（demo 预览缺口）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled Hugo version so preview environments can start successfully with newer theme requirements.
  * Resolved a failure where older container images could not parse themes that rely on newer Hugo features.
  * Documented the version update in the changelog for the unreleased build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->