### PR TITLE
chore(release): v2.5.5 升级镜像 hugo 0.163.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.5] - 2026-06-29
+
 ### Fixed
-- 镜像内 Hugo 版本过旧：Dockerfile 锁在 `0.121.1`（2023-12），跑不动现代主题——如作者自己的 Fried-Rice（`theme.toml` 要求 `min_version = 0.157.0`，用到 `hash.FNV32a` / `mod` 等 0.121 不支持的函数），admin「启动 Hugo 服务器」后 hugo 进程立即 parse fail 退出。升级到 `0.163.3`（对齐本机 dev 环境 0.163.1）。影响：jd demo 预览闭环（1313 反代到 `demo-blog.sun-praise.com`）此前 hugo server 起不来，升级后可用。
+- 镜像内 Hugo 版本过旧：Dockerfile 锁在 `0.121.1`（2023-12），跑不动现代主题——如作者自己的 Fried-Rice（`theme.toml` 要求 `min_version = 0.157.0`，用到 `hash.FNV32a` / `mod` 等 0.121 不支持的函数），admin「启动 Hugo 服务器」后 hugo 进程立即 parse fail 退出。升级到 `0.163.3`（对齐本机 dev 环境 0.163.1）。影响：jd demo 预览闭环（1313 反代到 `demo-blog.sun-praise.com`）此前 hugo server 起不来，升级后可用。见 #132。
 
 ## [2.5.4] - 2026-06-28
 

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
 Hugo Admin version information.
 """
 
-__version__ = "2.5.4"
+__version__ = "2.5.5"
 __version_info__ = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
发版 v2.5.5，内容为 PR #132（升级镜像 hugo 0.121.1→0.163.3）。

## 改动
- `__version__.py`：2.5.4 → 2.5.5
- `CHANGELOG.md`：新增 `[2.5.5] - 2026-06-29` 段

## 合并后
打 tag `v2.5.5`，触发 `docker-image.yml` verify-version + 构建推送镜像。随后部署到 jd demo，配通预览闭环（见 Svtter/ops#93 + issue #131）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **2.5.5**.
  * Added a new **2.5.5** release entry to the changelog.
  * Moved the existing fix note into the new release section for clearer release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->