### PR TITLE
ci(pages): 把 deploy 凭据收到 deploy job 内 (zizmor fix)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,16 +17,17 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-# 最小权限：pages 写、id-token 签发（deploy-pages 需要）
+# workflow 级别只给 read；Pages / OIDC 凭据收在 deploy job 内
+# build 只装 PyPI 包 + 跑 mkdocs build，不应持有部署凭据
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
     name: Build site
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,6 +64,9 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - 重组 mkdocs 文档结构：把 `DOCKER.md` 移入 `docs/docker.md`（保留 git 历史），新增「部署」分区（Docker 部署、Demo 服务器部署），使用指南补齐「剪贴板图片粘贴」，开发文档补齐「整体发布功能」；`docs/index.md` 改为完整文档导览页；启用 `repo_url` / `edit_uri` 与 Material 9.x 的 `content.action.{edit,view}` 特性，每页加「编辑此页」与「查看源码」按钮，页脚补 GitHub 仓库与 Docker 镜像链接。同步删除 `docs/README.md`（与根目录 `README.md` + `README.zh-CN.md` 重复、且与 `index.md` 在 mkdocs 中冲突）；`docs/development/preview-optimized.md` 是单行占位、移除。
 
+### Security
+- CI: pages workflow 把 `pages: write` / `id-token: write` 从 workflow 级别收到 `deploy` job 内，`build` job 只能 `contents: read`。build job 装 PyPI 包、跑 mkdocs build，不需要部署凭据；收窄后即使 build 链被攻破（恶意 mkdocs/pymdown release）也无法部署或改 Pages。zizmor 标记的 `overly broad permissions` 错误。
+
 ### Added
 - CI: GitHub Pages 部署 workflow（`.github/workflows/pages.yml`），main 推送 docs/mkdocs.yml 变更时自动 `mkdocs build --strict` + `actions/deploy-pages@v4` 发布到 https://sun-praise.github.io/hugo-admin/。mkdocs 依赖收进 `pyproject.toml` 的 `docs` extra 与 uv.lock（mkdocs 1.6.1 / material 9.6.8 / pymdown-extensions 10.14.3），workflow 用 `uv sync --extra docs --no-dev` + `uv run mkdocs build`，与 `test.yml` 的 Python 工具链一致；`mkdocs.yml` 新增 `site_url` 让 canonical / sitemap 指向 Pages 路径。
 


### PR DESCRIPTION
## 背景

#138 合并后，CodeRabbit + zizmor (1.26.1) 标记 `.github/workflows/pages.yml` 为 `overly broad permissions` **error**：

> `pages: write` / `id-token: write` 在 workflow 级别，`build` job 也继承了 deploy 凭据，但 `build` 实际只装 PyPI 包 + 跑 `mkdocs build --strict`，根本不需要。

## 修复

```diff
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
+    permissions:
+      contents: read
     steps:
       ...
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - uses: actions/deploy-pages@v4
```

## 安全收益

- **build job 拿不到 deploy 凭据**：即使 mkdocs / pymdown-extensions 之类的 PyPI 包被供应链攻破，攻击者只能影响 build 输出（注入坏 HTML），不能调 Pages API、不能改 GitHub Pages 站点
- **id-token 收窄**：OIDC token 只在需要它的 deploy job 颁发，减小 token 暴露面
- **符合最小权限**：每个 job 拿它真正需要的 token

## 验证

- yaml 解析合法（Python yaml.safe_load 通过）
- workflow → jobs.build.permissions = `{contents: read}`
- workflow → jobs.deploy.permissions = `{pages: write, id-token: write}`
- zizmor 期望：上述两个 permission 不再以 workflow 级别出现 → `overly broad permissions` 错误消失

## 配套改动

- `CHANGELOG.md` `## [Unreleased]` 新增 `### Security` 段（与既有 Changed / Added / Fixed 共存）

## 关联

- 上游 PR: #138 (已合入，本次是 follow-up)
- CodeRabbit 评论: https://github.com/sun-praise/hugo-admin/pull/138#discussion_r3489227606
- zizmor rule: `excessive-permissions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened deployment permissions for GitHub Pages so only the final deployment step can publish updates.
  * Reduced the risk of a compromised build process affecting the live site.
* **Documentation**
  * Updated the changelog to reflect the security hardening for Pages deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->