### PR TITLE
docs(readme): 加 GitHub Pages 文档站链接

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - 重组 mkdocs 文档结构：把 `DOCKER.md` 移入 `docs/docker.md`（保留 git 历史），新增「部署」分区（Docker 部署、Demo 服务器部署），使用指南补齐「剪贴板图片粘贴」，开发文档补齐「整体发布功能」；`docs/index.md` 改为完整文档导览页；启用 `repo_url` / `edit_uri` 与 Material 9.x 的 `content.action.{edit,view}` 特性，每页加「编辑此页」与「查看源码」按钮，页脚补 GitHub 仓库与 Docker 镜像链接。同步删除 `docs/README.md`（与根目录 `README.md` + `README.zh-CN.md` 重复、且与 `index.md` 在 mkdocs 中冲突）；`docs/development/preview-optimized.md` 是单行占位、移除。
 
+### Added
+- README: 顶部 badge + 单独的「Documentation」段落指向 https://sun-praise.github.io/hugo-admin/，列出核心章节直接链接。`README.md` 与 `README.zh-CN.md` 都加（保持现有英文/中文拆分的结构）。
+
 ### Security
 - CI: pages workflow 把 `pages: write` / `id-token: write` 从 workflow 级别收到 `deploy` job 内，`build` job 只能 `contents: read`。build job 装 PyPI 包、跑 mkdocs build，不需要部署凭据；收窄后即使 build 链被攻破（恶意 mkdocs/pymdown release）也无法部署或改 Pages。zizmor 标记的 `overly broad permissions` 错误。
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Tests](https://github.com/Svtter/hugo-admin/workflows/Tests/badge.svg)](https://github.com/Svtter/hugo-admin/actions)
 [![License](https://img.shields.io/github/license/Svtter/hugo-admin)](https://github.com/Svtter/hugo-admin/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/downloads/)
+[![Documentation](https://img.shields.io/badge/docs-mkdocs--material-blue)](https://sun-praise.github.io/hugo-admin/)
 [![Hugo](https://img.shields.io/badge/hugo-compatible-ff4088)](https://gohugo.io/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
@@ -174,6 +175,22 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 - [x] Password-based admin login
 - [ ] Batch operations
 - [ ] Multi-user support
+
+## Documentation
+
+Full documentation (deployment, usage, development, changelog) is available at:
+
+**https://sun-praise.github.io/hugo-admin/**
+
+Topics include:
+
+- [Docker deployment](https://sun-praise.github.io/hugo-admin/docker/)
+- [Quick start](https://sun-praise.github.io/hugo-admin/QUICKSTART/)
+- [Cache system](https://sun-praise.github.io/hugo-admin/CACHE_USAGE/)
+- [GitHub setup](https://sun-praise.github.io/hugo-admin/GITHUB_SETUP/)
+- [Frontmatter refactor](https://sun-praise.github.io/hugo-admin/FRONTMATTER_REFACTOR/)
+
+Built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/); source lives in [`docs/`](docs/), auto-deployed via [`.github/workflows/pages.yml`](.github/workflows/pages.yml).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,6 +3,7 @@
 [![Tests](https://github.com/Svtter/hugo-admin/workflows/Tests/badge.svg)](https://github.com/Svtter/hugo-admin/actions)
 [![License](https://img.shields.io/github/license/Svtter/hugo-admin)](https://github.com/Svtter/hugo-admin/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/downloads/)
+[![文档](https://img.shields.io/badge/文档-mkdocs--material-blue)](https://sun-praise.github.io/hugo-admin/)
 [![Hugo](https://img.shields.io/badge/hugo-compatible-ff4088)](https://gohugo.io/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
@@ -174,6 +175,22 @@ hugo-admin/
 - [x] 基于密码的管理员登录
 - [ ] 批量操作
 - [ ] 多用户支持
+
+## 文档
+
+完整文档（部署、使用、开发、变更日志）已部署到 GitHub Pages：
+
+**https://sun-praise.github.io/hugo-admin/**
+
+主要章节：
+
+- [Docker 部署](https://sun-praise.github.io/hugo-admin/docker/)
+- [快速开始](https://sun-praise.github.io/hugo-admin/QUICKSTART/)
+- [缓存使用](https://sun-praise.github.io/hugo-admin/CACHE_USAGE/)
+- [GitHub 设置](https://sun-praise.github.io/hugo-admin/GITHUB_SETUP/)
+- [Frontmatter 重构](https://sun-praise.github.io/hugo-admin/FRONTMATTER_REFACTOR/)
+
+使用 [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) 构建，源文件在 [`docs/`](docs/)，由 [`.github/workflows/pages.yml`](.github/workflows/pages.yml) 自动部署。
 
 ## 许可证
 


### PR DESCRIPTION
## 背景

#138 + #139 把 mkdocs docs 站部署到 https://sun-praise.github.io/hugo-admin/，但根目录 `README` / `README.zh-CN.md` 还没体现——访问者只有从 GitHub 仓库进来才能知道有 docs 站。

## 改动

- `README.md` / `README.zh-CN.md`：
  - 顶部 badges 块加 Documentation 徽章（shields.io 风格，与现有 License/Python/Hugo/Code style 一致）
  - 新增 `## Documentation` 段（在 License 段前），列核心章节直接链接：Docker 部署 / 快速开始 / 缓存使用 / GitHub 设置 / Frontmatter 重构
  - 注明 docs 站由 MkDocs Material + `.github/workflows/pages.yml` 自动部署
- `CHANGELOG.md`：`## [Unreleased]` 加 `### Added` 段记录

## 设计

- 徽章用 shields.io，颜色 / label 跟现有 4 个徽章保持统一（blue 色 + badge 风格）
- 文档段落用直接列链接，不嵌套——README 是入口，docs 站是详细参考
- 英文 / 中文 README 都加，保持现有拆分（不像 docs 站里那份双语合并版）

## 验证

- 链接目标已确认存在（#139 merge 后 docs 站已部署到 Pages）
- 徽章 URL shields.io 通用格式
- `pre-commit` hooks 全过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a documentation badge to the top of the English and Chinese README files.
  * Added a new documentation section with links to the published docs site and key topic pages.
  * Included guidance on where the docs content lives and that it is automatically published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->