### PR TITLE
fix(mkdocs): 中文标题 anchor 用 Unicode slug 替代 _1/_2/...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- mkdocs: 中文标题 anchor 不再退化成 `_1`/`_2`/`...`。`toc` 扩展用默认 slugifier 会把非 ASCII 字符 strip 掉，pages 上右侧大纲、URL 锚点全是无意义数字串（#_2 之类）。改用 `pymdownx.slugs.slugify(case=lower)` 保留 Unicode，URL 仍 URL-safe（小写 + 连字符）。影响 10 个含中文标题的 docs 页面（CACHE_USAGE / QUICKSTART / FRONTMATTER_REFACTOR / plan/demo-deployment 等）。
+
 ### Changed
 - 重组 mkdocs 文档结构：把 `DOCKER.md` 移入 `docs/docker.md`（保留 git 历史），新增「部署」分区（Docker 部署、Demo 服务器部署），使用指南补齐「剪贴板图片粘贴」，开发文档补齐「整体发布功能」；`docs/index.md` 改为完整文档导览页；启用 `repo_url` / `edit_uri` 与 Material 9.x 的 `content.action.{edit,view}` 特性，每页加「编辑此页」与「查看源码」按钮，页脚补 GitHub 仓库与 Docker 镜像链接。同步删除 `docs/README.md`（与根目录 `README.md` + `README.zh-CN.md` 重复、且与 `index.md` 在 mkdocs 中冲突）；`docs/development/preview-optimized.md` 是单行占位、移除。
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,11 @@ markdown_extensions:
   - meta
   - toc:
       permalink: true
+      # 默认 slugifier 会 strip 非 ASCII 字符，中文标题退化成 _1/_2/...
+      # 用 pymdownx.slugs.slugify 保留 Unicode，URL 仍 URL-safe（小写 + 连字符）
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - pymdownx.arithmatex
   - pymdownx.betterem:
       smart_enable: all


### PR DESCRIPTION
## 背景

https://sun-praise.github.io/hugo-admin/plan/demo-deployment/#_2 报渲染问题。原因是 `toc` 扩展用默认 slugifier（Python `markdown.extensions.toc.slugify`）会把非 ASCII 字符全 strip 掉，中文标题退化成 `_1`/`_2`/`_3`/`...`，每加一个中文标题 `++`，重复时还会变成 `_5`/`_6` 这种纯数字下标。

表现：
- 右侧大纲（Material outline）只显示 "1 2 3 4" 这种无意义编号
- URL 锚点 `#_2` 不可读、无法预测，分享链接无意义
- 同一 doc 多个中文子标题产生 collision

## 修复

`mkdocs.yml` 给 `toc` 扩展传 `slugify: pymdownx.slugs.slugify(case=lower)`：

```yaml
- toc:
    permalink: true
    slugify: !!python/object/apply:pymdownx.slugs.slugify
      kwds:
        case: lower
```

pymdownx 的 slugify 用 UnicodeNF + 保留非 ASCII，结果是 URL-safe（小写 + 连字符）但保留中文。

## Before / After

| H 标题 | Before | After |
|---|---|---|
| `## 目标` | `#_1` | `#目标` |
| `## 架构` | `#_2` | `#架构` |
| `## 资源限制` | `#_3` | `#资源限制` |
| `## 部署步骤` | `#_4` | `#部署步骤` |
| `### 2. SECRET_KEY 生成` | `#2-secret_key` | `#2-secret_key-生成` |
| `### 5. Nginx 反代 (HTTPS)` | `#5-nginx-https` | `#5-nginx-反代-https` |

## 验证

- `mkdocs build --strict` 0 警告
- `grep -rE 'id="_[0-9]+"' site/` 0 命中
- 影响 10 个含中文标题的页面（CACHE_USAGE / QUICKSTART / FRONTMATTER_REFACTOR / TEST_REPORT / CLIPBOARD_IMAGE_PASTE / FIXES / FIX_SUMMARY / plan/demo-deployment / index 等）

## 配套

- `CHANGELOG.md` `## [Unreleased]` 新增 `### Fixed` 段

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed anchor links for pages with Chinese headings so they remain readable and consistent instead of falling back to numbered fragments.
  * Improved documentation link generation to keep URLs Unicode-friendly while still safe for use in browsers.
  * Updated the release notes to reflect the anchor-link fix across affected documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->