### PR TITLE
fix(mkdocs): 代码块迁到 pymdownx.highlight + Material 现代路径

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- mkdocs: ``` 代码块渲染走 Material 现代路径——移除老的 `codehilite`（与 `pymdownx.superfences` + `pymdownx.highlight` 冲突，吃了 fence 块后输出 `<div class="codehilite">`、没 Material 钩子、Copy 按钮/行号/行高亮都挂不上）；给 `pymdownx.highlight` 配 Material 推荐参数（`anchor_linenums` / `line_spans=__span` / `pygments_lang_class`），theme features 启用 `content.code.copy`。所有 bash/yaml/nginx/text 块都换成 `<div class="language-xxx highlight">`，Material 样式与 Copy 按钮生效。
 - mkdocs: 中文标题 anchor 不再退化成 `_1`/`_2`/`...`。`toc` 扩展用默认 slugifier 会把非 ASCII 字符 strip 掉，pages 上右侧大纲、URL 锚点全是无意义数字串（#_2 之类）。改用 `pymdownx.slugs.slugify(case=lower)` 保留 Unicode，URL 仍 URL-safe（小写 + 连字符）。影响 10 个含中文标题的 docs 页面（CACHE_USAGE / QUICKSTART / FRONTMATTER_REFACTOR / plan/demo-deployment 等）。
 
 ### Changed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,8 @@ theme:
     - navigation.sections
     - navigation.top
     - navigation.tracking
+    # content.code.copy: 在代码块右上角加 Copy 按钮（需要 pymdownx.highlight，codehilite 不会触发）
+    - content.code.copy
     - content.code.annotate
     - content.tabs.link
     - content.action.edit
@@ -47,7 +49,6 @@ plugins:
 # 扩展配置
 markdown_extensions:
   - admonition
-  - codehilite
   - footnotes
   - meta
   - toc:
@@ -66,7 +67,16 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - pymdownx.highlight
+  # pymdownx.highlight 配 Material theme 用：
+  #   anchor_linenums:  给行号加 anchor（分享链接定位到某行）
+  #   line_spans:       用 __span 包行（给行高亮、复制按钮用）
+  #   pygments_lang_class: 给 <code> 加 language-bash 之类类名
+  #   auto_title:       显示语言名（前提是 md 写 ```bash 那种 fence 头）
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+      auto_title: false
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.mark


### PR DESCRIPTION
## 背景

PR #141（中文 anchor 修复）合了，但同一页面 `plan/demo-deployment.md` 还有第二个渲染问题：```bash 代码块走的是 `codehilite` 老路径。

`codehilite`（Python-Markdown 老扩展）跟 `pymdownx.superfences` + `pymdownx.highlight` 冲突——codehilite 先把 fence 块吃了，输出 `<div class="codehilite">`，pymdownx.superfences 拿不到，Material theme 的现代 hook 全失效：

- **无 Copy 按钮**（Material `content.code.copy` 找不到挂载点）
- **无行号**（`linenums="1"` 不识别）
- **无行高亮**（行没被 `<span class="__span-N">` 包）
- **无 `language-bash` 类名**（CSS 钩子全失效）

## 修复

`mkdocs.yml`：

```diff
-  - codehilite                  # 移除
-  - pymdownx.highlight          # 默认配置 → 显式 Material 配置
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+      auto_title: false

 theme.features:
+    - content.code.copy         # 新增
```

## 验证

- `mkdocs build --strict` 0 警告
- `grep -rc codehilite site/` 0（站点里再无老标记）
- 所有 fence 块输出 `<div class="language-xxx highlight">`（5 个 bash / 1 个 nginx / 1 个 text / 2 个 yaml 在 demo-deployment）

## 关联

- PR #141（已合）：slug 修复
- 同一页面 `plan/demo-deployment.md` 的两个独立渲染问题，分两个 PR 走

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block rendering in documentation to avoid styling conflicts and display fenced blocks more reliably.
  * Enabled copy-to-clipboard support for code snippets.
  * Updated syntax highlighting behavior for common block types like bash, YAML, nginx, and plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->