### PR TITLE
chore: switch default image model to Nano Banana 2

### DIFF
--- a/services/image_gen_service.py
+++ b/services/image_gen_service.py
@@ -8,7 +8,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "google/gemini-3-pro-image-preview"
+DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview"
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 
 


### PR DESCRIPTION
## Summary
- 将默认图像生成模型从 `google/gemini-3-pro-image-preview` (Nano Banana Pro) 切换为 `google/gemini-3.1-flash-image-preview` (Nano Banana 2)

## Motivation
- Nano Banana 2 更新、更快，适合做封面图生成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default image generation model used when no specific model is selected, bringing cover image generation to a newer preview model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->