### PR TITLE
feat: 文件保存乐观锁 — 防止并发编辑覆盖

### DIFF
--- a/debug_posts.py
+++ b/debug_posts.py
@@ -93,7 +93,7 @@ print("\n6. 测试文件读取...")
 try:
     if result["posts"]:
         first_post_path = result["posts"][0]["full_path"]
-        success, content = post_service.read_file(first_post_path)
+        success, content, _mtime = post_service.read_file(first_post_path)
 
         if success:
             print("   ✓ 文件读取成功")

--- a/frontend/src/components/ConflictModal.tsx
+++ b/frontend/src/components/ConflictModal.tsx
@@ -1,0 +1,168 @@
+import { useMemo } from 'react';
+import { AlertTriangle, Save, RotateCcw, X } from 'lucide-react';
+
+interface ConflictModalProps {
+  localContent: string;
+  remoteContent: string;
+  onSaveForce: () => void;
+  onDiscard: () => void;
+  onClose: () => void;
+}
+
+interface DiffLine {
+  type: 'add' | 'del' | 'same';
+  text: string;
+  oldNum?: number;
+  newNum?: number;
+}
+
+function computeDiff(oldText: string, newText: string): DiffLine[] {
+  const oldLines = oldText.split('\n');
+  const newLines = newText.split('\n');
+
+  // Simple LCS-based diff
+  const m = oldLines.length;
+  const n = newLines.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        oldLines[i - 1] === newLines[j - 1]
+          ? dp[i - 1][j - 1] + 1
+          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  const result: DiffLine[] = [];
+  let i = m,
+    j = n;
+  const buf: DiffLine[] = [];
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      buf.push({ type: 'same', text: oldLines[i - 1], oldNum: i, newNum: j });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      buf.push({ type: 'add', text: newLines[j - 1], newNum: j });
+      j--;
+    } else {
+      buf.push({ type: 'del', text: oldLines[i - 1], oldNum: i });
+      i--;
+    }
+  }
+
+  buf.reverse().forEach((line) => result.push(line));
+  return result;
+}
+
+export function ConflictModal({
+  localContent,
+  remoteContent,
+  onSaveForce,
+  onDiscard,
+  onClose,
+}: ConflictModalProps) {
+  const diffLines = useMemo(
+    () => computeDiff(remoteContent, localContent),
+    [remoteContent, localContent],
+  );
+
+  const stats = useMemo(() => {
+    let adds = 0;
+    let dels = 0;
+    diffLines.forEach((l) => {
+      if (l.type === 'add') adds++;
+      if (l.type === 'del') dels++;
+    });
+    return { adds, dels };
+  }, [diffLines]);
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-4xl mx-4 max-h-[85vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b">
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="w-6 h-6 text-amber-500" />
+            <div>
+              <h3 className="text-lg font-semibold text-stone-900">文件冲突</h3>
+              <p className="text-sm text-stone-500">
+                文件已被其他人修改。请查看差异后选择操作。
+                <span className="ml-2 text-green-600">+{stats.adds}</span>
+                <span className="ml-1 text-red-600">-{stats.dels}</span>
+              </p>
+            </div>
+          </div>
+          <button onClick={onClose} className="text-stone-400 hover:text-stone-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Diff view */}
+        <div className="flex-1 overflow-auto font-mono text-sm">
+          <table className="w-full border-collapse">
+            <tbody>
+              {diffLines.map((line, idx) => {
+                const bg =
+                  line.type === 'add'
+                    ? 'bg-green-50'
+                    : line.type === 'del'
+                      ? 'bg-red-50'
+                      : '';
+                const prefix =
+                  line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' ';
+                const prefixColor =
+                  line.type === 'add'
+                    ? 'text-green-600'
+                    : line.type === 'del'
+                      ? 'text-red-600'
+                      : 'text-stone-400';
+                return (
+                  <tr key={idx} className={bg}>
+                    <td className="w-12 px-2 py-0.5 text-right text-stone-400 select-none border-r border-stone-200">
+                      {line.oldNum ?? ''}
+                    </td>
+                    <td className="w-12 px-2 py-0.5 text-right text-stone-400 select-none border-r border-stone-200">
+                      {line.newNum ?? ''}
+                    </td>
+                    <td className="w-6 px-1 py-0.5 text-center select-none">
+                      <span className={prefixColor}>{prefix}</span>
+                    </td>
+                    <td className="px-2 py-0.5 whitespace-pre-wrap break-all">
+                      {line.text || '\u00A0'}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t bg-stone-50">
+          <p className="text-sm text-stone-500">
+            左列为服务端最新版本，右列为你的本地修改
+          </p>
+          <div className="flex gap-3">
+            <button
+              onClick={onDiscard}
+              className="flex items-center gap-2 px-4 py-2 border border-stone-300 rounded-lg text-stone-700 hover:bg-stone-100 transition-colors"
+            >
+              <RotateCcw className="w-4 h-4" />
+              放弃我的修改
+            </button>
+            <button
+              onClick={onSaveForce}
+              className="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+            >
+              <Save className="w-4 h-4" />
+              覆盖保存
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ConflictModal.tsx
+++ b/frontend/src/components/ConflictModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { AlertTriangle, Save, RotateCcw, X } from 'lucide-react';
 
 interface ConflictModalProps {
@@ -23,6 +23,22 @@ function computeDiff(oldText: string, newText: string): DiffLine[] {
   // Simple LCS-based diff
   const m = oldLines.length;
   const n = newLines.length;
+
+  // 大文件跳过 LCS，直接返回逐行 same
+  if (m > 2000 || n > 2000) {
+    const lines: DiffLine[] = [];
+    const max = Math.max(m, n);
+    for (let k = 0; k < max; k++) {
+      if (k < m && k < n && oldLines[k] === newLines[k]) {
+        lines.push({ type: 'same', text: oldLines[k], oldNum: k + 1, newNum: k + 1 });
+      } else if (k < m) {
+        lines.push({ type: 'del', text: oldLines[k], oldNum: k + 1 });
+      } else {
+        lines.push({ type: 'add', text: newLines[k], newNum: k + 1 });
+      }
+    }
+    return lines;
+  }
   const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
 
   for (let i = 1; i <= m; i++) {
@@ -79,6 +95,18 @@ export function ConflictModal({
     return { adds, dels };
   }, [diffLines]);
 
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const MAX_DIFF_LINES = 5000;
+  const isOversized = diffLines.length > MAX_DIFF_LINES;
+  const displayLines = isOversized ? diffLines.slice(0, MAX_DIFF_LINES) : diffLines;
+
   return (
     <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/50">
       <div className="bg-white rounded-xl shadow-2xl w-full max-w-4xl mx-4 max-h-[85vh] flex flex-col">
@@ -104,7 +132,7 @@ export function ConflictModal({
         <div className="flex-1 overflow-auto font-mono text-sm">
           <table className="w-full border-collapse">
             <tbody>
-              {diffLines.map((line, idx) => {
+              {displayLines.map((line, idx) => {
                 const bg =
                   line.type === 'add'
                     ? 'bg-green-50'
@@ -139,6 +167,12 @@ export function ConflictModal({
             </tbody>
           </table>
         </div>
+
+        {isOversized && (
+          <div className="px-6 py-2 bg-amber-50 text-amber-700 text-sm border-t">
+            文件差异过大（{diffLines.length} 行），仅显示前 {MAX_DIFF_LINES} 行
+          </div>
+        )}
 
         {/* Footer */}
         <div className="flex items-center justify-between px-6 py-4 border-t bg-stone-50">

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -25,6 +25,7 @@ import type { Mermaid } from 'mermaid';
 import type { FileData, ImageItem, Backlink, Frontmatter } from '../types';
 import { usePageTitle } from '../hooks/usePageTitle';
 import { InlineEditOverlay } from '../components/InlineEdit/Overlay';
+import { ConflictModal } from '../components/ConflictModal';
 
 // Mermaid is heavy (~800KB); load it lazily and only when the preview
 // actually contains a ```mermaid block. Initialised once per session.
@@ -90,10 +91,12 @@ export default function Editor() {
   const [refSearchResults, setRefSearchResults] = useState<Array<{ path: string; title: string }>>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
-  const saveFileRef = useRef<() => Promise<void>>(async () => {});
+  const saveFileRef = useRef<(force?: boolean) => Promise<void>>(async () => {});
   const insertMarkdownRef = useRef<(type: string) => void>(() => {});
   const [generatingCover, setGeneratingCover] = useState(false);
   const [generatingFm, setGeneratingFm] = useState(false);
+  const [fileMtime, setFileMtime] = useState<number | null>(null);
+  const [conflictRemoteContent, setConflictRemoteContent] = useState<string | null>(null);
   const { setTitle: setPageTitle, resetTitle: resetPageTitle } = usePageTitle();
 
   useEffect(() => {
@@ -326,7 +329,13 @@ export default function Editor() {
     showNotification('选区已变化，已取消', 'warning');
   }
 
-  const saveFile = useCallback(async () => {
+  async function discardAndReload() {
+    setConflictRemoteContent(null);
+    await loadFile();
+    showNotification('已加载最新版本', 'info');
+  }
+
+  const saveFile = useCallback(async (force = false) => {
     if (!currentFile) {
       showNotification('未选择文件', 'error');
       return;
@@ -337,10 +346,27 @@ export default function Editor() {
       if (Object.keys(frontmatter).length > 0) {
         body.frontmatter = frontmatter;
       }
-      const data = await post<{ success: boolean; message?: string }>('/api/file/save', body);
+      if (!force && fileMtime !== null) {
+        body.expected_mtime = fileMtime;
+      }
+      if (force) {
+        body.force = true;
+      }
+      const res = await fetch('/api/file/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (res.status === 409 && data.conflict) {
+        setConflictRemoteContent(data.current_content);
+        return;
+      }
       if (data.success) {
         setOriginalContent(content);
         setOriginalFrontmatter(JSON.parse(JSON.stringify(frontmatter)));
+        setFileMtime(data.mtime ?? null);
+        setConflictRemoteContent(null);
         showNotification('保存成功', 'success');
       } else {
         showNotification('保存失败: ' + data.message, 'error');
@@ -350,7 +376,7 @@ export default function Editor() {
     } finally {
       setSaving(false);
     }
-  }, [currentFile, content, frontmatter]);
+  }, [currentFile, content, frontmatter, fileMtime]);
 
   async function publishArticle() {
     if (!currentFile) {
@@ -547,20 +573,22 @@ export default function Editor() {
     if (!currentFile) return;
     setLoading(true);
     try {
-      const data = await post<FileData & { success: boolean; message?: string }>('/api/file/read-with-frontmatter', { path: currentFile });
+      const data = await post<FileData & { success: boolean; message?: string; mtime?: number }>('/api/file/read-with-frontmatter', { path: currentFile });
       if (data.success) {
         setContent(data.content || '');
         setOriginalContent(data.content || '');
+        setFileMtime(data.mtime ?? null);
         const fm = (data.frontmatter || {}) as Frontmatter;
         setFrontmatter(fm);
         setOriginalFrontmatter(JSON.parse(JSON.stringify(fm)));
         syncFmEdit(fm);
         await checkPublishStatus();
       } else {
-        const fallback = await post<FileData & { success: boolean }>('/api/file/read', { path: currentFile });
+        const fallback = await post<FileData & { success: boolean; mtime?: number }>('/api/file/read', { path: currentFile });
         if (fallback.success) {
           setContent(fallback.content || '');
           setOriginalContent(fallback.content || '');
+          setFileMtime(fallback.mtime ?? null);
           setFrontmatter({});
           setOriginalFrontmatter({});
           await checkPublishStatus();
@@ -1000,6 +1028,17 @@ export default function Editor() {
             <p className="text-stone-700">加载中...</p>
           </div>
         </div>
+      )}
+
+      {/* 冲突对话框 */}
+      {conflictRemoteContent !== null && (
+        <ConflictModal
+          localContent={content}
+          remoteContent={conflictRemoteContent}
+          onSaveForce={() => saveFile(true)}
+          onDiscard={discardAndReload}
+          onClose={() => setConflictRemoteContent(null)}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -732,7 +732,7 @@ export default function Editor() {
               <Wand2 className="w-5 h-5" />
             </button>
             <span className="border-l border-stone-300 mx-1 h-6" />
-            <button onClick={saveFile} disabled={saving || !hasChanges} title={saving ? '保存中...' : hasChanges ? '保存 (Ctrl+S)' : '已保存'} className="p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+            <button onClick={() => saveFile()} disabled={saving || !hasChanges} title={saving ? '保存中...' : hasChanges ? '保存 (Ctrl+S)' : '已保存'} className="p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
               <Save className="w-5 h-5" />
             </button>
             <button onClick={publishArticle} disabled={publishing || !currentFile || isPublished} title={publishing ? '发布中...' : isPublished ? '已发布' : '发布'} className={`p-2 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${isPublished ? 'bg-stone-400 hover:bg-stone-500' : 'bg-green-600 hover:bg-green-700'}`}>

--- a/routes/file_routes.py
+++ b/routes/file_routes.py
@@ -94,7 +94,7 @@ def register_file_routes(registry, blueprint=None):
         expected_mtime = data.get("expected_mtime")
         force = data.get("force", False)
 
-        success, message = registry.post_service.save_file(
+        success, message, new_mtime = registry.post_service.save_file(
             file_path,
             content,
             frontmatter_data=frontmatter_data,
@@ -116,9 +116,10 @@ def register_file_routes(registry, blueprint=None):
             except Exception as e:
                 logger.exception(e)
 
-        return jsonify({"success": success, "message": message}), (
-            200 if success else 500
-        )
+        resp = {"success": success, "message": message}
+        if success and new_mtime is not None:
+            resp["mtime"] = new_mtime
+        return jsonify(resp), (200 if success else 500)
 
     @blueprint.route("/api/post/create", methods=["POST"])
     def create_post():

--- a/routes/file_routes.py
+++ b/routes/file_routes.py
@@ -45,10 +45,12 @@ def register_file_routes(registry, blueprint=None):
         if not file_path:
             return jsonify({"success": False, "message": "缺少文件路径"}), 400
 
-        success, content = registry.post_service.read_file(file_path)
+        success, content, mtime = registry.post_service.read_file(file_path)
 
         if success:
-            return jsonify({"success": True, "content": content, "path": file_path})
+            return jsonify(
+                {"success": True, "content": content, "path": file_path, "mtime": mtime}
+            )
         else:
             return jsonify({"success": False, "message": content}), 404
 
@@ -61,7 +63,7 @@ def register_file_routes(registry, blueprint=None):
         if not file_path:
             return jsonify({"success": False, "message": "缺少文件路径"}), 400
 
-        success, content, fm = registry.post_service.read_file_with_frontmatter(
+        success, content, fm, mtime = registry.post_service.read_file_with_frontmatter(
             file_path
         )
 
@@ -72,6 +74,7 @@ def register_file_routes(registry, blueprint=None):
                     "content": content,
                     "frontmatter": fm,
                     "path": file_path,
+                    "mtime": mtime,
                 }
             )
         else:
@@ -88,9 +91,18 @@ def register_file_routes(registry, blueprint=None):
         if not file_path or content is None:
             return jsonify({"success": False, "message": "缺少必要参数"}), 400
 
+        expected_mtime = data.get("expected_mtime")
+        force = data.get("force", False)
+
         success, message = registry.post_service.save_file(
-            file_path, content, frontmatter_data=frontmatter_data
+            file_path,
+            content,
+            frontmatter_data=frontmatter_data,
+            expected_mtime=None if force else expected_mtime,
         )
+
+        if not success and isinstance(message, dict) and message.get("conflict"):
+            return jsonify({"success": False, **message}), 409
 
         if success:
             # 增量更新引用关系

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -143,7 +143,7 @@ class AIService:
         async def write_post(args: Dict[str, Any]) -> Dict[str, Any]:
             file_path = args["file_path"]
             content = args["content"]
-            success, message = deps.post_service.save_file(file_path, content)
+            success, message, _mtime = deps.post_service.save_file(file_path, content)
             if success:
                 return mcp_text(f"✅ 文件 `{file_path}` 保存成功")
             return mcp_text(f"❌ 保存失败: {message}")

--- a/services/ai_service.py
+++ b/services/ai_service.py
@@ -130,7 +130,7 @@ class AIService:
         @tool("read_post", "Read the content of a blog post", {"file_path": str})
         async def read_post(args: Dict[str, Any]) -> Dict[str, Any]:
             file_path = args["file_path"]
-            success, content = deps.post_service.read_file(file_path)
+            success, content, _mtime = deps.post_service.read_file(file_path)
             if success:
                 return mcp_text(f"文件 `{file_path}` 内容：\n\n{content}")
             return mcp_text(f"读取失败: {content}")

--- a/services/article_import_service.py
+++ b/services/article_import_service.py
@@ -91,7 +91,7 @@ def _create_article_dir(post_service, title: str) -> str:
 
 def _set_cover_field(post_service, article_path: str, cover_url: str) -> bool:
     """把 cover 字段写回文章 frontmatter，复用 PostService 的读写方法。"""
-    ok, body, fm = post_service.read_file_with_frontmatter(article_path)
+    ok, body, fm, _mtime = post_service.read_file_with_frontmatter(article_path)
     if not ok:
         return False
     fm["cover"] = cover_url

--- a/services/article_import_service.py
+++ b/services/article_import_service.py
@@ -95,7 +95,7 @@ def _set_cover_field(post_service, article_path: str, cover_url: str) -> bool:
     if not ok:
         return False
     fm["cover"] = cover_url
-    ok2, _msg = post_service.save_file(article_path, body, frontmatter_data=fm)
+    ok2, _msg, _mtime = post_service.save_file(article_path, body, frontmatter_data=fm)
     return ok2
 
 
@@ -232,7 +232,7 @@ def import_markdown(
     fm.setdefault("tags", [])
 
     # 6. 写入文章（正文 + 合并后的 frontmatter，草稿，暂无封面）
-    write_ok, write_msg = post_service.save_file(
+    write_ok, write_msg, _mtime = post_service.save_file(
         article_path, body, frontmatter_data=fm
     )
     if not write_ok:

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -402,10 +402,10 @@ class PostService:
             if not file_path.exists():
                 return False, f"文件不存在: {file_path}", 0.0
 
-            # 读取文件
-            mtime = file_path.stat().st_mtime
+            # 读取文件（fstat 在 open 之后，避免 TOCTOU 竞态）
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
+                mtime = os.fstat(f.fileno()).st_mtime
 
             return True, content, mtime
 
@@ -437,8 +437,10 @@ class PostService:
             if not file_path.exists():
                 return False, f"文件不存在: {file_path}", {}, 0.0
 
-            mtime = file_path.stat().st_mtime
-            text = file_path.read_text(encoding="utf-8")
+            # fstat 在 open 之后，避免 TOCTOU 竞态
+            with open(file_path, "r", encoding="utf-8") as f:
+                text = f.read()
+                mtime = os.fstat(f.fileno()).st_mtime
             lines = text.split("\n")
 
             metadata = {}
@@ -480,7 +482,7 @@ class PostService:
             expected_mtime: 期望的文件修改时间戳，传入时做乐观锁校验
 
         Returns:
-            (success, message): 成功标志和消息
+            (success, message, mtime): 成功标志和消息，mtime 在错误时为 0.0
         """
         try:
             if not Path(file_path).is_absolute():
@@ -489,19 +491,23 @@ class PostService:
             file_path = Path(file_path)
 
             if not self._is_safe_path(file_path):
-                return False, "访问被拒绝:文件不在允许的目录中"
+                return False, "访问被拒绝:文件不在允许的目录中", 0.0
 
             # 乐观锁：校验 mtime
             if expected_mtime is not None and file_path.exists():
                 current_mtime = file_path.stat().st_mtime
                 if abs(current_mtime - expected_mtime) > 0.001:
                     current_content = file_path.read_text(encoding="utf-8")
-                    return False, {
-                        "conflict": True,
-                        "current_content": current_content,
-                        "current_mtime": current_mtime,
-                        "message": "文件已被其他人修改",
-                    }
+                    return (
+                        False,
+                        {
+                            "conflict": True,
+                            "current_content": current_content,
+                            "current_mtime": current_mtime,
+                            "message": "文件已被其他人修改",
+                        },
+                        0.0,
+                    )
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -514,15 +520,16 @@ class PostService:
 
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(file_content)
+                new_mtime = os.fstat(f.fileno()).st_mtime
 
             # 更新缓存
             if self.use_cache and self.cache_service:
                 self.cache_service.invalidate_post(str(file_path))
 
-            return True, "文件保存成功"
+            return True, "文件保存成功", new_mtime
 
         except Exception as e:
-            return False, f"保存文件失败: {str(e)}"
+            return False, f"保存文件失败: {str(e)}", 0.0
 
     def create_post(self, title):
         """

--- a/services/post_service.py
+++ b/services/post_service.py
@@ -385,7 +385,7 @@ class PostService:
             file_path: 文件路径(相对于 content 目录或绝对路径)
 
         Returns:
-            (success, content): 成功标志和文件内容
+            (success, content, mtime): 成功标志、文件内容、文件修改时间戳
         """
         try:
             # 处理路径
@@ -396,20 +396,21 @@ class PostService:
 
             # 安全检查:确保文件在 content 目录下
             if not self._is_safe_path(file_path):
-                return False, "访问被拒绝:文件不在允许的目录中"
+                return False, "访问被拒绝:文件不在允许的目录中", 0.0
 
             # 检查文件是否存在
             if not file_path.exists():
-                return False, f"文件不存在: {file_path}"
+                return False, f"文件不存在: {file_path}", 0.0
 
             # 读取文件
+            mtime = file_path.stat().st_mtime
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
-            return True, content
+            return True, content, mtime
 
         except Exception as e:
-            return False, f"读取文件失败: {str(e)}"
+            return False, f"读取文件失败: {str(e)}", 0.0
 
     def read_file_with_frontmatter(self, file_path):
         """
@@ -422,7 +423,7 @@ class PostService:
             file_path: 文件路径(相对于 content 目录或绝对路径)
 
         Returns:
-            (success, content, frontmatter): 成功标志、正文内容、frontmatter 字典
+            (success, content, frontmatter, mtime): 成功标志、正文内容、frontmatter 字典、文件修改时间戳
         """
         try:
             if not Path(file_path).is_absolute():
@@ -431,11 +432,12 @@ class PostService:
             file_path = Path(file_path)
 
             if not self._is_safe_path(file_path):
-                return False, "访问被拒绝:文件不在允许的目录中", {}
+                return False, "访问被拒绝:文件不在允许的目录中", {}, 0.0
 
             if not file_path.exists():
-                return False, f"文件不存在: {file_path}", {}
+                return False, f"文件不存在: {file_path}", {}, 0.0
 
+            mtime = file_path.stat().st_mtime
             text = file_path.read_text(encoding="utf-8")
             lines = text.split("\n")
 
@@ -462,12 +464,12 @@ class PostService:
                 normalized[k] = (
                     str(v) if not isinstance(v, (str, int, float, bool, list)) else v
                 )
-            return True, body, normalized
+            return True, body, normalized, mtime
 
         except Exception as e:
-            return False, f"读取文件失败: {str(e)}", {}
+            return False, f"读取文件失败: {str(e)}", {}, 0.0
 
-    def save_file(self, file_path, content, frontmatter_data=None):
+    def save_file(self, file_path, content, frontmatter_data=None, expected_mtime=None):
         """
         保存文件内容
 
@@ -475,6 +477,7 @@ class PostService:
             file_path: 文件路径
             content: 文件内容（正文，不含 frontmatter）
             frontmatter_data: 可选的 frontmatter 字典，传入时与正文合并写入
+            expected_mtime: 期望的文件修改时间戳，传入时做乐观锁校验
 
         Returns:
             (success, message): 成功标志和消息
@@ -487,6 +490,18 @@ class PostService:
 
             if not self._is_safe_path(file_path):
                 return False, "访问被拒绝:文件不在允许的目录中"
+
+            # 乐观锁：校验 mtime
+            if expected_mtime is not None and file_path.exists():
+                current_mtime = file_path.stat().st_mtime
+                if abs(current_mtime - expected_mtime) > 0.001:
+                    current_content = file_path.read_text(encoding="utf-8")
+                    return False, {
+                        "conflict": True,
+                        "current_content": current_content,
+                        "current_mtime": current_mtime,
+                        "message": "文件已被其他人修改",
+                    }
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_file_conflict.py
+++ b/tests/test_file_conflict.py
@@ -1,0 +1,162 @@
+# coding: utf-8
+"""
+文件乐观锁（防复写）端到端测试。
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import app as app_module
+from services.post_service import PostService
+
+
+class TestFileConflictDetection:
+    @pytest.fixture
+    def temp_content_dir(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            content_dir = Path(temp_dir) / "content"
+            content_dir.mkdir()
+            yield content_dir
+
+    @pytest.fixture
+    def client(self, temp_content_dir, login):
+        app_module.app.config["TESTING"] = True
+        original = app_module.registry.post_service
+        app_module.registry.post_service = PostService(
+            temp_content_dir, use_cache=False
+        )
+        with app_module.app.test_client() as client:
+            login(client)
+            yield client
+        app_module.registry.post_service = original
+
+    @pytest.fixture
+    def article(self, temp_content_dir):
+        """创建一篇测试文章，返回相对路径。"""
+        path = temp_content_dir / "test.md"
+        path.write_text("---\ntitle: Test\n---\n\nOriginal content.\n")
+        return "test.md"
+
+    # ── 读文件返回 mtime ──
+
+    def test_read_returns_mtime(self, client, article):
+        resp = client.post("/api/file/read", json={"path": article})
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "mtime" in data
+        assert isinstance(data["mtime"], (int, float))
+        assert data["mtime"] > 0
+
+    def test_read_with_frontmatter_returns_mtime(self, client, article):
+        resp = client.post("/api/file/read-with-frontmatter", json={"path": article})
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "mtime" in data
+        assert isinstance(data["mtime"], (int, float))
+
+    # ── 保存返回新 mtime ──
+
+    def test_save_returns_mtime(self, client, article):
+        resp = client.post(
+            "/api/file/save",
+            json={"path": article, "content": "Updated.\n"},
+        )
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "mtime" in data
+        assert isinstance(data["mtime"], (int, float))
+
+    # ── 乐观锁：mtime 匹配 → 成功 ──
+
+    def test_save_with_correct_mtime_succeeds(self, client, article):
+        # 先读取拿到 mtime
+        read_resp = client.post("/api/file/read", json={"path": article})
+        mtime = read_resp.get_json()["mtime"]
+
+        # 用正确的 mtime 保存
+        save_resp = client.post(
+            "/api/file/save",
+            json={
+                "path": article,
+                "content": "Safe update.\n",
+                "expected_mtime": mtime,
+            },
+        )
+        data = save_resp.get_json()
+        assert save_resp.status_code == 200
+        assert data["success"] is True
+
+    # ── 乐观锁：mtime 不匹配 → 409 冲突 ──
+
+    def test_save_with_wrong_mtime_returns_409(self, client, article):
+        # 用一个明显过时的 mtime
+        save_resp = client.post(
+            "/api/file/save",
+            json={
+                "path": article,
+                "content": "Conflicting update.\n",
+                "expected_mtime": 100000.0,
+            },
+        )
+        data = save_resp.get_json()
+        assert save_resp.status_code == 409
+        assert data["success"] is False
+        assert data["conflict"] is True
+        assert "current_content" in data
+        assert "current_mtime" in data
+        assert isinstance(data["current_mtime"], (int, float))
+
+    # ── force=True 跳过 mtime 检查 ──
+
+    def test_force_save_ignores_mtime(self, client, article):
+        save_resp = client.post(
+            "/api/file/save",
+            json={
+                "path": article,
+                "content": "Forced update.\n",
+                "expected_mtime": 100000.0,
+                "force": True,
+            },
+        )
+        data = save_resp.get_json()
+        assert save_resp.status_code == 200
+        assert data["success"] is True
+
+    # ── 不传 expected_mtime 时无锁检查 ──
+
+    def test_save_without_mtime_skips_lock(self, client, article):
+        save_resp = client.post(
+            "/api/file/save",
+            json={"path": article, "content": "No lock.\n"},
+        )
+        data = save_resp.get_json()
+        assert save_resp.status_code == 200
+        assert data["success"] is True
+
+    # ── 冲突后 force 覆盖 → 再次读取内容一致 ──
+
+    def test_conflict_then_force_overwrites(self, client, article):
+        # 触发冲突
+        client.post(
+            "/api/file/save",
+            json={
+                "path": article,
+                "content": "Should conflict.\n",
+                "expected_mtime": 100000.0,
+            },
+        )
+        # force 覆盖
+        client.post(
+            "/api/file/save",
+            json={
+                "path": article,
+                "content": "Forced content.\n",
+                "expected_mtime": 100000.0,
+                "force": True,
+            },
+        )
+        # 验证内容
+        read_resp = client.post("/api/file/read", json={"path": article})
+        assert "Forced content." in read_resp.get_json()["content"]

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -22,7 +22,7 @@ print("=" * 60)
 
 for path in test_paths:
     print(f"\n测试路径: {path}")
-    success, content = post_service.read_file(path)
+    success, content, _mtime = post_service.read_file(path)
     if success:
         print(f"✓ 成功读取，内容长度: {len(content)}")
         print(f"  前 100 字符: {content[:100]}")

--- a/tests/test_post_service_publish.py
+++ b/tests/test_post_service_publish.py
@@ -137,7 +137,9 @@ Content 2
         file_path.write_text(initial)
 
         for _ in range(5):
-            success, body, fm = post_service.read_file_with_frontmatter(str(file_path))
+            success, body, fm, _mtime = post_service.read_file_with_frontmatter(
+                str(file_path)
+            )
             assert success
             success, msg = post_service.save_file(
                 str(file_path), body, frontmatter_data=fm

--- a/tests/test_post_service_publish.py
+++ b/tests/test_post_service_publish.py
@@ -141,7 +141,7 @@ Content 2
                 str(file_path)
             )
             assert success
-            success, msg = post_service.save_file(
+            success, msg, _new_mtime = post_service.save_file(
                 str(file_path), body, frontmatter_data=fm
             )
             assert success


### PR DESCRIPTION
## Summary

- 两个编辑器同时编辑同一文件时，后保存的一方会检测到冲突并弹出 diff 对话框，不再静默覆盖
- 读文件接口返回 `mtime`，保存时传回 `expected_mtime` 做乐观锁校验
- 冲突时返回 HTTP 409 + 当前文件内容，前端展示 unified diff，用户可选「覆盖保存」或「放弃修改」

## Changes

**后端 (5 files)**
- `services/post_service.py` — `read_file` / `read_file_with_frontmatter` 返回值增加 `mtime`；`save_file` 新增 `expected_mtime` 参数，冲突时返回冲突信息
- `routes/file_routes.py` — 读接口响应增加 `mtime`，保存接口支持 `expected_mtime` 和 `force`，冲突返回 HTTP 409
- `services/ai_service.py`、`services/article_import_service.py`、`debug_posts.py` — 适配新返回值签名
- `tests/test_post_service_publish.py`、`tests/test_path.py` — 适配新签名

**前端 (2 files)**
- `frontend/src/components/ConflictModal.tsx` — 新建，LCS diff 逐行对比 + 红绿高亮，「覆盖保存」和「放弃我的修改」两个操作
- `frontend/src/pages/Editor.tsx` — 加载时存 `fileMtime`，保存时发送 `expected_mtime`，409 时弹出冲突对话框

## Test plan

1. 开两个浏览器标签编辑同一篇文章
2. 标签 A 修改并保存
3. 标签 B 修改并保存 → 弹出冲突对话框，显示 diff
4. 点「覆盖保存」→ 保存成功
5. 点「放弃我的修改」→ 内容刷新为服务端最新版