### PR TITLE
feat(tts): 新增 TTS 语音播报插件能力 (tts_generation)

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,7 @@ from routes import (
     register_settings_routes,
     register_socketio_handlers,
     register_theme_routes,
+    register_tts_routes,
 )
 from routes.plugin_routes import register_plugin_routes
 from routes.settings_routes import _ensure_server_url_has_port
@@ -248,11 +249,12 @@ ai_main_bp, fm_bp = register_ai_routes(get_ai_service)
 app.register_blueprint(ai_main_bp)
 app.register_blueprint(fm_bp)
 app.register_blueprint(register_inline_edit_routes(get_ai_service))
-app.register_blueprint(register_plugin_routes(plugin_manager))
+app.register_blueprint(register_plugin_routes(plugin_manager, socketio))
 app.register_blueprint(register_auth_routes(registry))
 app.register_blueprint(register_project_init_routes(app, registry))
 app.register_blueprint(register_theme_routes(registry))
 app.register_blueprint(register_config_routes(app))
+app.register_blueprint(register_tts_routes(registry))
 
 # 全局会话守卫：在所有 Blueprint 注册后挂载，未登录访问 /api/* 一律 401
 # （白名单 /api/auth/login、/api/auth/me、/api/version 除外）。

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -725,19 +725,21 @@ export default function Editor() {
       setGeneratingTts(false);
       setTtsProgress(null);
       if (d.url) {
+        const url = d.url;
+        const fmt = d.format || '';
         // 持久化后端已写入的全部音频字段，避免下次保存把它们丢掉
         //（audioUrl 由 frontmatter.audio 派生，无需单独 setAudioUrl）
         setFrontmatter((prev) => ({
           ...prev,
-          audio: d.url,
+          audio: url,
           audio_duration_seconds: d.duration_seconds,
-          audio_format: d.format,
+          audio_format: fmt,
         }));
         setFmEdit((prev) => ({
           ...prev,
-          audio: d.url,
+          audio: url,
           audio_duration_seconds: d.duration_seconds ? String(d.duration_seconds) : '',
-          audio_format: d.format,
+          audio_format: fmt,
         }));
         // 后端已保存文件，刷新 fileMtime 避免下次手动保存触发假冲突
         if (d.mtime) setFileMtime(d.mtime);

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -18,12 +18,19 @@ import {
   ArrowLeftRight,
   Sparkles,
   Wand2,
+  Headphones,
 } from 'lucide-react';
 import { get, post } from '../utils/api';
+import {
+  generateArticleTTS,
+  deleteArticleTTS,
+  getTTSStatus,
+} from '../utils/api';
 import { renderMarkdown, escapeHtml } from '../utils/markdown';
 import type { Mermaid } from 'mermaid';
 import type { FileData, ImageItem, Backlink, Frontmatter } from '../types';
 import { usePageTitle } from '../hooks/usePageTitle';
+import { useSocket } from '../hooks/useSocket';
 import { InlineEditOverlay } from '../components/InlineEdit/Overlay';
 import { ConflictModal } from '../components/ConflictModal';
 
@@ -98,6 +105,16 @@ export default function Editor() {
   const [fileMtime, setFileMtime] = useState<number | null>(null);
   const [conflictRemoteContent, setConflictRemoteContent] = useState<string | null>(null);
   const { setTitle: setPageTitle, resetTitle: resetPageTitle } = usePageTitle();
+
+  // TTS 语音播报
+  const socketRef = useSocket();
+  const [ttsAvailable, setTtsAvailable] = useState(false);
+  const [ttsVoices, setTtsVoices] = useState<string[]>([]);
+  const [generatingTts, setGeneratingTts] = useState(false);
+  const [ttsProgress, setTtsProgress] = useState<{ stage: string; percent: number; message: string } | null>(null);
+  const [ttsVoice, setTtsVoice] = useState('');
+  const [ttsSpeed, setTtsSpeed] = useState(1.0);
+  const [audioUrl, setAudioUrl] = useState('');
 
   useEffect(() => {
     if (frontmatter.title) {
@@ -463,6 +480,63 @@ export default function Editor() {
     }
   }
 
+  async function generateSpeech() {
+    if (!currentFile) {
+      showNotification('未选择文件', 'error');
+      return;
+    }
+    if (!content.trim()) {
+      showNotification('文章内容为空', 'error');
+      return;
+    }
+    setGeneratingTts(true);
+    setTtsProgress({ stage: 'starting', percent: 0, message: '' });
+    try {
+      const data = await generateArticleTTS(currentFile, {
+        voice: ttsVoice || undefined,
+        speed: ttsSpeed,
+      });
+      if (!data.success) {
+        setGeneratingTts(false);
+        setTtsProgress(null);
+        showNotification('语音生成失败: ' + (data.message || '未知错误'), 'error');
+      }
+      // pending=true 时进度与结果由 Socket.IO 事件驱动
+    } catch {
+      setGeneratingTts(false);
+      setTtsProgress(null);
+      showNotification('语音生成请求失败', 'error');
+    }
+  }
+
+  async function deleteSpeech() {
+    if (!currentFile) return;
+    if (!confirm('确定删除该文章的语音播报？')) return;
+    try {
+      const data = await deleteArticleTTS(currentFile);
+      if (data.success) {
+        setAudioUrl('');
+        setFrontmatter((prev) => {
+          const next = { ...prev };
+          delete next.audio;
+          delete next.audio_duration_seconds;
+          delete next.audio_format;
+          return next;
+        });
+        setFmEdit((prev) => {
+          const next = { ...prev };
+          delete next.audio;
+          return next;
+        });
+        showNotification('已删除语音', 'success');
+      } else {
+        showNotification('删除失败: ' + (data.message || '未知错误'), 'error');
+      }
+    } catch {
+      showNotification('删除语音失败', 'error');
+    }
+  }
+
   async function generateFrontmatterFromAI() {
     if (!currentFile || !content.trim()) {
       showNotification('文章内容为空', 'error');
@@ -619,6 +693,67 @@ export default function Editor() {
     })();
   }, [currentFile, loadFile, loadImages, loadBacklinks]);
 
+  // 同步 frontmatter.audio 到 audioUrl 状态（loadFile/保存后随之更新）
+  useEffect(() => {
+    const a = frontmatter.audio;
+    setAudioUrl(typeof a === 'string' ? a : '');
+  }, [frontmatter.audio]);
+
+  // 查询 TTS 能力是否可用（控制按钮显隐）
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const st = await getTTSStatus();
+        if (cancelled) return;
+        setTtsAvailable(st.available);
+        setTtsVoices(st.voices || []);
+      } catch {
+        if (!cancelled) setTtsAvailable(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // 监听 TTS Socket.IO 进度/结果事件
+  useEffect(() => {
+    const socket = socketRef.current;
+    if (!socket) return;
+    const onProgress = (d: { stage?: string; percent?: number; message?: string }) => {
+      setTtsProgress({ stage: d.stage || '', percent: d.percent ?? 0, message: d.message || '' });
+    };
+    const onDone = (d: { url?: string; duration_seconds?: number }) => {
+      setGeneratingTts(false);
+      setTtsProgress(null);
+      if (d.url) {
+        setAudioUrl(d.url);
+        setFrontmatter((prev) => ({ ...prev, audio: d.url }));
+        setFmEdit((prev) => ({ ...prev, audio: d.url }));
+        showNotification('语音播报已生成', 'success');
+      }
+    };
+    const onFailed = (d: { message?: string }) => {
+      setGeneratingTts(false);
+      setTtsProgress(null);
+      showNotification('语音生成失败: ' + (d.message || '未知错误'), 'error');
+    };
+    const onConflict = (d: { message?: string }) => {
+      setGeneratingTts(false);
+      setTtsProgress(null);
+      showNotification(d.message || '文章已被修改，请保存后重试', 'warning');
+    };
+    socket.on('tts.progress', onProgress);
+    socket.on('tts.done', onDone);
+    socket.on('tts.failed', onFailed);
+    socket.on('tts.conflict', onConflict);
+    return () => {
+      socket.off('tts.progress', onProgress);
+      socket.off('tts.done', onDone);
+      socket.off('tts.failed', onFailed);
+      socket.off('tts.conflict', onConflict);
+    };
+  }, [socketRef]);
+
   useEffect(() => {
     (async () => {
       await updatePreview();
@@ -731,6 +866,11 @@ export default function Editor() {
             <button onClick={generateFrontmatterFromAI} disabled={generatingFm || !currentFile} title={generatingFm ? '生成中...' : 'AI 生成 Frontmatter'} className="p-2 border border-amber-400 text-amber-700 rounded-lg hover:bg-amber-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
               <Wand2 className="w-5 h-5" />
             </button>
+            {ttsAvailable && (
+              <button onClick={generateSpeech} disabled={generatingTts || !currentFile} title={generatingTts ? '生成语音中...' : '生成语音播报'} className="p-2 border border-emerald-400 text-emerald-700 rounded-lg hover:bg-emerald-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                <Headphones className="w-5 h-5" />
+              </button>
+            )}
             <span className="border-l border-stone-300 mx-1 h-6" />
             <button onClick={() => saveFile()} disabled={saving || !hasChanges} title={saving ? '保存中...' : hasChanges ? '保存 (Ctrl+S)' : '已保存'} className="p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
               <Save className="w-5 h-5" />
@@ -749,6 +889,42 @@ export default function Editor() {
               </div>
               <span className="text-sm text-stone-600 whitespace-nowrap">{generatingCover ? 'AI 生成封面中...' : 'AI 生成 Frontmatter 中...'}</span>
             </div>
+          </div>
+        )}
+
+        {/* TTS 语音播报参数面板 + 进度 */}
+        {ttsAvailable && (
+          <div className="bg-white rounded-md ring-1 ring-stone-900/5 p-3 mb-4">
+            <div className="flex items-center gap-3 flex-wrap">
+              <span className="text-sm font-medium text-stone-700">语音播报</span>
+              {ttsVoices.length > 0 && (
+                <select value={ttsVoice} onChange={(e) => setTtsVoice(e.target.value)} className="px-2 py-1 border border-stone-300 rounded-lg text-sm" disabled={generatingTts}>
+                  {ttsVoices.map((v) => (<option key={v} value={v}>{v}</option>))}
+                </select>
+              )}
+              <label className="flex items-center gap-2 text-sm text-stone-600">
+                语速
+                <input type="range" min={0.5} max={2} step={0.1} value={ttsSpeed} onChange={(e) => setTtsSpeed(parseFloat(e.target.value))} disabled={generatingTts} className="w-28" />
+                <span className="font-mono w-8">{ttsSpeed.toFixed(1)}</span>
+              </label>
+              <button onClick={generateSpeech} disabled={generatingTts || !currentFile} className="px-3 py-1 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                {audioUrl ? '重新生成' : '生成语音'}
+              </button>
+              {audioUrl && !generatingTts && (
+                <button onClick={deleteSpeech} className="px-3 py-1 border border-stone-300 text-stone-600 rounded-lg text-sm hover:bg-stone-50 transition-colors">删除</button>
+              )}
+            </div>
+            {generatingTts && (
+              <div className="flex items-center gap-3 mt-3">
+                <div className="w-full bg-stone-200 rounded-full h-2 overflow-hidden">
+                  <div className="h-2 rounded-full bg-emerald-500 transition-all" style={{ width: `${Math.min(100, ttsProgress?.percent || 0)}%` }} />
+                </div>
+                <span className="text-sm text-stone-600 whitespace-nowrap">{ttsProgress?.message || ttsProgress?.stage || '生成中...'}</span>
+              </div>
+            )}
+            {audioUrl && !generatingTts && (
+              <audio controls src={audioUrl} className="w-full mt-3" />
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -114,7 +114,6 @@ export default function Editor() {
   const [ttsProgress, setTtsProgress] = useState<{ stage: string; percent: number; message: string } | null>(null);
   const [ttsVoice, setTtsVoice] = useState('');
   const [ttsSpeed, setTtsSpeed] = useState(1.0);
-  const [audioUrl, setAudioUrl] = useState('');
 
   useEffect(() => {
     if (frontmatter.title) {
@@ -124,6 +123,9 @@ export default function Editor() {
   }, [frontmatter.title, setPageTitle, resetPageTitle]);
 
   const currentFile = fullPath;
+
+  // audioUrl 直接从 frontmatter.audio 派生，避免在 effect 里 setState（react-hooks/set-state-in-effect）
+  const audioUrl = typeof frontmatter.audio === 'string' ? frontmatter.audio : '';
 
   const updatePreview = useCallback(() => {
     let html = renderMarkdown(content || '', { mermaid: true });
@@ -515,7 +517,6 @@ export default function Editor() {
     try {
       const data = await deleteArticleTTS(currentFile);
       if (data.success) {
-        setAudioUrl('');
         setFrontmatter((prev) => {
           const next = { ...prev };
           delete next.audio;
@@ -695,11 +696,7 @@ export default function Editor() {
     })();
   }, [currentFile, loadFile, loadImages, loadBacklinks]);
 
-  // 同步 frontmatter.audio 到 audioUrl 状态（loadFile/保存后随之更新）
-  useEffect(() => {
-    const a = frontmatter.audio;
-    setAudioUrl(typeof a === 'string' ? a : '');
-  }, [frontmatter.audio]);
+  // audioUrl 直接派生自 frontmatter.audio（见上方 const audioUrl），无需 effect 同步
 
   // 查询 TTS 能力是否可用（控制按钮显隐）
   useEffect(() => {
@@ -728,8 +725,8 @@ export default function Editor() {
       setGeneratingTts(false);
       setTtsProgress(null);
       if (d.url) {
-        setAudioUrl(d.url);
         // 持久化后端已写入的全部音频字段，避免下次保存把它们丢掉
+        //（audioUrl 由 frontmatter.audio 派生，无需单独 setAudioUrl）
         setFrontmatter((prev) => ({
           ...prev,
           audio: d.url,

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -528,6 +528,8 @@ export default function Editor() {
           delete next.audio;
           return next;
         });
+        // 后端已保存文件，刷新 fileMtime 避免下次手动保存触发假冲突
+        if (data.mtime) setFileMtime(data.mtime);
         showNotification('已删除语音', 'success');
       } else {
         showNotification('删除失败: ' + (data.message || '未知错误'), 'error');
@@ -722,13 +724,26 @@ export default function Editor() {
     const onProgress = (d: { stage?: string; percent?: number; message?: string }) => {
       setTtsProgress({ stage: d.stage || '', percent: d.percent ?? 0, message: d.message || '' });
     };
-    const onDone = (d: { url?: string; duration_seconds?: number }) => {
+    const onDone = (d: { url?: string; duration_seconds?: number; format?: string; mtime?: number }) => {
       setGeneratingTts(false);
       setTtsProgress(null);
       if (d.url) {
         setAudioUrl(d.url);
-        setFrontmatter((prev) => ({ ...prev, audio: d.url }));
-        setFmEdit((prev) => ({ ...prev, audio: d.url }));
+        // 持久化后端已写入的全部音频字段，避免下次保存把它们丢掉
+        setFrontmatter((prev) => ({
+          ...prev,
+          audio: d.url,
+          audio_duration_seconds: d.duration_seconds,
+          audio_format: d.format,
+        }));
+        setFmEdit((prev) => ({
+          ...prev,
+          audio: d.url,
+          audio_duration_seconds: d.duration_seconds ? String(d.duration_seconds) : '',
+          audio_format: d.format,
+        }));
+        // 后端已保存文件，刷新 fileMtime 避免下次手动保存触发假冲突
+        if (d.mtime) setFileMtime(d.mtime);
         showNotification('语音播报已生成', 'success');
       }
     };

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -124,8 +124,8 @@ export async function generateArticleTTS(
 /**
  * 删除一篇文章的语音（清 frontmatter 音频字段，并通知插件删托管音频）。
  */
-export async function deleteArticleTTS(articlePath: string): Promise<{ success: boolean; message?: string }> {
-  return request<{ success: boolean; message?: string }>('/api/article/tts', {
+export async function deleteArticleTTS(articlePath: string): Promise<{ success: boolean; message?: string; mtime?: number }> {
+  return request<{ success: boolean; message?: string; mtime?: number }>('/api/article/tts', {
     method: 'DELETE',
     body: JSON.stringify({ article_path: articlePath }),
   });

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -84,6 +84,53 @@ export async function uploadMarkdown(
   return request<ImportResult>('/api/article/import', { method: 'POST', body: form });
 }
 
+// ============ TTS 语音播报 ============
+
+export interface TTSStatus {
+  success: boolean;
+  available: boolean;
+  plugin?: string | null;
+  voices: string[];
+}
+
+export interface TTSGenerateResult {
+  success: boolean;
+  pending: boolean;
+  event_scope: string;
+  message?: string;
+}
+
+/**
+ * 查询 TTS 能力是否可用（前端据此显隐"生成语音"按钮）。
+ */
+export async function getTTSStatus(): Promise<TTSStatus> {
+  return get<TTSStatus>('/api/article/tts/status');
+}
+
+/**
+ * 为一篇文章生成语音播报。立即返回 event_scope，进度与结果经 Socket.IO
+ * （tts.progress / tts.done / tts.failed / tts.conflict）上报。
+ */
+export async function generateArticleTTS(
+  articlePath: string,
+  opts?: { voice?: string; model?: string; speed?: number; format?: string; language?: string },
+): Promise<TTSGenerateResult> {
+  return post<TTSGenerateResult>('/api/article/tts', {
+    article_path: articlePath,
+    ...opts,
+  });
+}
+
+/**
+ * 删除一篇文章的语音（清 frontmatter 音频字段，并通知插件删托管音频）。
+ */
+export async function deleteArticleTTS(articlePath: string): Promise<{ success: boolean; message?: string }> {
+  return request<{ success: boolean; message?: string }>('/api/article/tts', {
+    method: 'DELETE',
+    body: JSON.stringify({ article_path: articlePath }),
+  });
+}
+
 // ============ Git 历史 ============
 
 export interface CommitStats {

--- a/openspec/changes/add-tts-plugin/design.md
+++ b/openspec/changes/add-tts-plugin/design.md
@@ -1,0 +1,75 @@
+## Context
+
+hugo-admin 已有一套成熟的 gRPC 子进程插件系统（`add-plugin-system` 变更），但目前只接了 `image_upload` 一种能力。本变更新增 `tts_generation` 能力，让用户能给博客文章生成语音播报。
+
+- 语音来源：小米 MiMo TTS（OpenAI 兼容 `chat/completions`，`modalities:["audio"]`，响应 `data[0].data` 为 base64 音频）。
+- 音频托管：Cloudflare R2（S3 兼容），frontmatter `audio:` 字段引用公网 URL。
+- 触发位置：编辑器内按钮 + 内联 `<audio>` 播放器（与"生成封面"对称）。
+- host 端开源扩展协议/路由/前端；MiMo 与 R2 的实际调用放在闭源 Go 插件（独立私有仓库）。
+
+## Goals / Non-Goals
+
+### Goals
+- 在既有插件协议上**新增**一种能力，不破坏 `image_upload`
+- host 端不感知 MiMo / Cloudflare 细节，只负责读正文、转发进度、写回 frontmatter
+- 长任务（TTS 合成 + 上传）走后台任务 + Socket.IO 进度，HTTP 立即返回
+- frontmatter 写回用乐观锁，冲突可被前端处理（与编辑器既有 ConflictModal 一致）
+
+### Non-Goals
+- 自动下载/签名校验安装（host 当前本就是手动安装，保持一致）
+- 前台 Hugo 主题的 `<audio>` 渲染（那是博客主题侧，hugo-admin 只约定 `audio:` 字段）
+- 音色设计/复刻 UI（V1 用预设音色 + 语速；V2 再扩）
+
+## Decisions
+
+### Decision 1: 能力解耦对称 —— 插件"生成+托管"一体返回 URL
+
+TTS 插件对外只返回公网 URL（+ audio_id 供删除），与 `ImageUploader.Upload` 返回 `url` 完全对称。host 不接触音频二进制、不感知 R2 / MiMo —— 这些都是插件的实现细节。好处：换语音供应商 / 换托管商都不用动 host；插件闭源也不会泄漏 host 侧。
+
+### Decision 2: 协议向后兼容 —— 新增可选服务
+
+`TTSGenerator` 作为新的可选 gRPC 服务加入 `plugin.proto`，与 `ImageUploader` 并列。`protocol_version` 维持 `"1"`。没有 TTS 插件时，编辑器按 `list_plugins()` 是否存在该能力决定按钮显隐。
+
+### Decision 3: 服务端流式 + Socket.IO 转发
+
+`Generate` 用 gRPC **服务端流式**（`returns (stream TTSResponse)`）：插件边合成边发 `TTSProgress`，最后一条 `TTSResult`。host 迭代流，把 progress 包经 `socketio.emit("tts.progress", {scope, stage, percent})` 转发给前端。复刻 `article_import_service.py` 的后台任务模式：HTTP 立即返回 `event_scope`，长任务在 `socketio.start_background_task` 中跑。
+
+### Decision 4: 两层路由 —— 能力代理 + 文章集成
+
+- **能力代理**（`plugin_routes.py`）：`/api/plugins/<name>/tts/...` 直通插件，不碰文章；适合任意 TTS 调用方。
+- **文章集成**（`tts_routes.py`）：`/api/article/tts` 读正文 → 调能力代理选中的插件 → 写回 frontmatter；面向编辑器。
+
+这与 `image_upload` 的两层（`plugin_routes` 代理 + `image_routes.generate_cover` 集成）结构一致。
+
+### Decision 5: frontmatter 写回用乐观锁
+
+后台任务拿到 URL 后，用 `post_service.save_file(article_path, body, frontmatter | {audio: url}, expected_mtime)` 写回。`expected_mtime` 取自任务启动时读文件的 mtime。冲突则 emit `tts.conflict` 事件，前端引导重试或放弃（与编辑器既有 ConflictModal 的语义一致，不自动覆盖）。
+
+### Decision 6: 音频元信息随 frontmatter 落地
+
+除 `audio: <url>` 外，同时写 `audio_duration_seconds` 与 `audio_format`（可选），方便 Hugo 主题渲染。插件在 `TTSResult` 里返回这些值。
+
+### Decision 7: 删除语义
+
+`DELETE /api/article/tts` 既调插件 `Delete(audio_id)` 删 R2 object，又清空 frontmatter 的 `audio*` 字段。`audio_id` 暂存在内存不可行（后台任务结束即丢），故约定：frontmatter 额外存一个**非公开**字段 `_tts_audio_id` 作为删除凭证。若缺失则只清 frontmatter、不调插件 Delete（降级）。
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| MiMo 单次合成有长度上限 | 插件侧分片合成 + 拼接，host 侧不感知；进度按分片上报 |
+| 后台任务期间文章被改 | 乐观锁 + `tts.conflict` 事件，前端引导处理 |
+| R2 凭据泄漏 | 走插件 config_schema，host 用 Fernet 加密落盘（既有机制），明文仅在 `SetConfig` 时下发 |
+| 旧插件不含 `TTSGenerator` 服务 | 它是可选服务；`get_tts_generator_stub` 仅对声明该能力的插件调用 |
+| Go 1.21 与 aws-sdk-go-v2 | 插件 go.mod 锁定兼容版本；host 不关心插件 Go 版本 |
+| 音频重复生成产生 R2 垃圾 | 重新生成时先 Delete 旧 audio_id（若 frontmatter 有凭证） |
+
+## Migration Plan
+
+1. 扩展 `proto/plugin.proto`，重新生成 Python 桩（host）
+2. host：plugin_manager stub → plugin_routes 代理 → tts_routes 文章集成 → app 注册
+3. 前端：api 封装 → Editor 按钮/播放器/进度
+4. Go 插件独立仓库：骨架 → MiMo → R2 → plugin.toml → CI
+5. 测试：host 单测覆盖；端到端自测留给用户（需 MiMo/R2 凭据）
+
+无破坏性变更：既有 `image_upload` 流程与 API 不受影响。

--- a/openspec/changes/add-tts-plugin/design.md
+++ b/openspec/changes/add-tts-plugin/design.md
@@ -53,6 +53,17 @@ TTS 插件对外只返回公网 URL（+ audio_id 供删除），与 `ImageUpload
 
 `DELETE /api/article/tts` 既调插件 `Delete(audio_id)` 删 R2 object，又清空 frontmatter 的 `audio*` 字段。`audio_id` 暂存在内存不可行（后台任务结束即丢），故约定：frontmatter 额外存一个**非公开**字段 `_tts_audio_id` 作为删除凭证。若缺失则只清 frontmatter、不调插件 Delete（降级）。
 
+### Decision 8: mtime 一致性 —— 后端写回后必须回传新 mtime
+
+生成与删除两条路径都会在后台/请求中保存文章文件（改变 mtime）。若不把**新 mtime** 回传给前端，前端持有的 `fileMtime` 就会变陈旧，下一次手动保存带上旧 `expected_mtime`，触发编辑器既有 ConflictModal 的**假冲突**——用户并未手动改文件却被弹冲突框。
+
+因此：
+- `tts.done` Socket 事件携带 `mtime`（写入成功后的新 mtime）
+- `DELETE /api/article/tts` 响应携带 `mtime`
+- 前端 `onDone` / `deleteSpeech` 收到后调用 `setFileMtime(mtime)` 刷新
+
+这样编辑器的乐观锁基准始终与磁盘一致，避免假冲突。
+
 ## Risks / Trade-offs
 
 | Risk | Mitigation |

--- a/openspec/changes/add-tts-plugin/proposal.md
+++ b/openspec/changes/add-tts-plugin/proposal.md
@@ -1,0 +1,29 @@
+# Change: Add TTS Speech Generation Plugin Capability
+
+## Why
+
+hugo-admin 已有基于 gRPC 子进程的插件系统，但目前只接了 `image_upload` 一种能力。用户希望给自己的博客文章生成语音播报（text-to-speech），便于读者"听文章"。小米 MiMo 提供了高质量的 TTS 接口（OpenAI 兼容），适合作为语音来源；生成的音频需要托管到公网（Cloudflare R2）并通过 frontmatter 的 `audio` 字段引用。
+
+本次新增一种插件能力 `tts_generation`，沿用既有插件机制：host 端（开源）只扩展协议、能力路由与文章集成层；实际调用 MiMo 与 R2 托管的逻辑放在闭源的 Go 插件（独立私有仓库 `../tts-gen-plugin`）中。
+
+## What Changes
+
+- **Plugin Protocol**: 在 `proto/plugin.proto` 新增可选能力服务 `TTSGenerator`（`Generate` 服务端流式 + `Delete`），与 `ImageUploader` 并列，不破坏既有协议。
+- **Plugin Manager**: `services/plugin_manager.py` 新增 `get_tts_generator_stub()` 与 `find_plugin_with_capability()` 通用辅助方法（顺带把 `image_routes.py` 里内联的"按能力找运行中插件"循环抽出来复用）。
+- **Capability Proxy Routes**: `routes/plugin_routes.py` 新增 `POST /api/plugins/<name>/tts/generate`（流式进度经 Socket.IO 转发）与 `DELETE /api/plugins/<name>/tts/<audio_id>`。
+- **Article Integration**: 新建 `routes/tts_routes.py`，`POST /api/article/tts` —— 读正文、调用带 `tts_generation` 能力的插件、后台任务经 Socket.IO 上报进度、成功后用乐观锁把 `audio` 写回 frontmatter。复刻 `article_import_service.py` 的后台任务 + 进度事件模式。
+- **Frontend**: `Editor.tsx` 新增"生成语音播报"按钮（参数面板：音色/语速/模型/格式），进度经 Socket.IO 实时显示，完成后内联渲染 `<audio>` 播放器；`utils/api.ts` 新增类型化封装。
+- **Go Plugin**: 独立私有仓库 `tts-gen-plugin`，实现 `PluginService` + `TTSGenerator`，调用 MiMo TTS 并上传 Cloudflare R2，返回公网 URL。
+
+## Impact
+
+- Affected specs: 新增 spec `tts-generation`
+- Affected code:
+  - Modified: `proto/plugin.proto`（新增 TTS 服务与消息）、`proto/plugin_pb2.py` / `proto/plugin_pb2_grpc.py`（重新生成）
+  - Modified: `services/plugin_manager.py`（stub 获取器 + 能力查找辅助）
+  - Modified: `routes/plugin_routes.py`（TTS 能力代理路由）、`routes/image_routes.py`（复用能力查找）
+  - New: `routes/tts_routes.py`、`app.py`（注册新蓝图）、`routes/__init__.py`（导出）
+  - New: `tests/test_tts_routes.py`、`tests/test_plugin_manager.py`（补 stub 用例）
+  - Modified: `frontend/src/pages/Editor.tsx`、`frontend/src/utils/api.ts`
+- External: 新私有 Go 仓库 `tts-gen-plugin`（独立仓库，不进 hugo-admin）
+- New dependencies: 无 Python 新依赖（已有 `grpcio`/`grpcio-tools`）；Go 侧 `google.golang.org/grpc`、`aws-sdk-go-v2`（R2 走 S3 兼容 API）

--- a/openspec/changes/add-tts-plugin/specs/tts-generation/spec.md
+++ b/openspec/changes/add-tts-plugin/specs/tts-generation/spec.md
@@ -1,0 +1,46 @@
+# Spec: TTS Speech Generation
+
+## Requirements
+
+### REQ-1: 插件协议支持 TTS 能力
+The system SHALL allow plugins to declare a `tts_generation` capability by implementing the optional `TTSGenerator` gRPC service (`Generate` server-streaming + `Delete`), declared in the plugin manifest's `[capabilities]` section.
+
+### REQ-2: 文章级语音生成
+The system SHALL provide `POST /api/article/tts` that reads an article's body (stripping frontmatter), invokes a running plugin with `tts_generation`, and writes the resulting public audio URL into the article's frontmatter `audio` field.
+
+### REQ-3: 异步进度上报
+The system SHALL return immediately from `/api/article/tts` with an `event_scope`, and stream progress via Socket.IO events `tts.progress`, `tts.done`, `tts.failed`, and `tts.conflict`, each carrying the `scope` for client correlation.
+
+### REQ-4: 乐观锁写回
+The system SHALL write the `audio` field back using optimistic locking (`expected_mtime`); on mtime mismatch it SHALL emit `tts.conflict` instead of overwriting.
+
+### REQ-5: 能力代理直通
+The system SHALL provide `POST /api/plugins/<name>/tts/generate` and `DELETE /api/plugins/<name>/tts/<audio_id>` that proxy directly to a plugin's `TTSGenerator` service without touching article content.
+
+### REQ-6: 无插件降级
+When no running plugin provides `tts_generation`, the article-TTS endpoint SHALL return HTTP 400 with a clear message, and the frontend SHALL hide/disable the generate button.
+
+### REQ-7: 删除语音
+The system SHALL provide `DELETE /api/article/tts` that removes the frontmatter `audio` (and related) fields and, when an audio deletion id is available, asks the plugin to delete the hosted audio object.
+
+## Scenarios
+
+**Scenario: 生成语音播报**
+- **GIVEN** 一个声明 `tts_generation` 的插件已启用、配置完整
+- **WHEN** 用户在编辑器点击"生成语音播报"并提交
+- **THEN** 系统返回 `event_scope`，前端收到 `tts.progress`，最终收到 `tts.done {url, duration_seconds}`，且文章 frontmatter 的 `audio` 字段被更新为该 URL
+
+**Scenario: 无 TTS 插件**
+- **GIVEN** 没有任何运行中的插件提供 `tts_generation`
+- **WHEN** 用户尝试生成语音
+- **THEN** 系统返回 400 "未找到支持 tts_generation 的插件"，前端按钮置灰/隐藏
+
+**Scenario: 生成期间文章被修改**
+- **GIVEN** TTS 后台任务进行中，文章被另一会话保存
+- **WHEN** 任务尝试写回 frontmatter
+- **THEN** 系统检测到 mtime 不匹配，emit `tts.conflict {current_mtime}`，不覆盖文件；前端提示冲突
+
+**Scenario: 删除语音**
+- **GIVEN** 文章 frontmatter 含 `audio` 与删除凭证
+- **WHEN** 用户点击删除
+- **THEN** 系统清除 frontmatter 的音频字段，并通知插件删除托管 object

--- a/openspec/changes/add-tts-plugin/tasks.md
+++ b/openspec/changes/add-tts-plugin/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Add TTS Speech Generation Plugin Capability
+
+## 1. Protocol
+
+- [x] 1.1 在 `proto/plugin.proto` 新增 `TTSGenerator` 服务（`Generate` 服务端流式 + `Delete`）及 `TTSRequest`/`TTSResponse`(`oneof payload`)/`TTSProgress`/`TTSResult`/`TTSDeleteRequest`/`TTSDeleteResponse` 消息
+- [x] 1.2 用 `grpcio-tools` 重新生成 `proto/plugin_pb2.py` 与 `proto/plugin_pb2_grpc.py`
+
+## 2. Host — Plugin Manager
+
+- [x] 2.1 `services/plugin_manager.py` 新增 `get_tts_generator_stub(name)`
+- [x] 2.2 新增通用 `find_plugin_with_capability(capability)` 辅助方法
+- [x] 2.3 `routes/image_routes.py` 的内联能力查找改为复用 `find_plugin_with_capability`
+
+## 3. Host — Routes
+
+- [x] 3.1 `routes/plugin_routes.py` 新增 `POST /api/plugins/<name>/tts/generate`（迭代服务端流，progress 经 Socket.IO 转发）
+- [x] 3.2 `routes/plugin_routes.py` 新增 `DELETE /api/plugins/<name>/tts/<audio_id>`
+- [x] 3.3 新建 `routes/tts_routes.py`：`POST /api/article/tts`（读正文 → 后台任务生成 → 乐观锁写回 frontmatter → Socket.IO 进度）
+- [x] 3.4 新建 `DELETE /api/article/tts`（删 frontmatter `audio` 字段）
+- [x] 3.5 `routes/__init__.py` 导出 `register_tts_routes`；`app.py` 注册蓝图（需 `socketio` 与 `plugin_manager` 注入）
+
+## 4. Frontend
+
+- [x] 4.1 `utils/api.ts` 新增 `generateArticleTTS` / `deleteArticleTTS` 类型化封装
+- [x] 4.2 `Editor.tsx` 新增"生成语音播报"按钮 + 参数面板（音色/语速/模型/格式）
+- [x] 4.3 监听 `tts.progress`/`tts.done`/`tts.failed`/`tts.conflict`（基于 `useSocket`），实时进度
+- [x] 4.4 frontmatter 含 `audio` 时内联渲染 `<audio>` 播放器 + 重新生成 / 删除
+
+## 5. Go Plugin（独立私有仓库 `tts-gen-plugin`）
+
+- [x] 5.1 `git init` + `go mod init` + 复制 `plugin.proto` 生成 Go 桩
+- [x] 5.2 `cmd/tts-gen-plugin/main.go`：解析 `--port`，起 gRPC server，注册 `PluginService` + `TTSGenerator`
+- [x] 5.3 `internal/server`：`Info`/`HealthCheck`/`GetConfigSchema`/`SetConfig`
+- [x] 5.4 `internal/mimo`：调用 MiMo `chat/completions`（`modalities:["audio"]`），解析 base64 音频
+- [x] 5.5 `internal/r2`：Cloudflare R2（S3 兼容）上传 / 删除
+- [x] 5.6 `Generate`：分片合成 → 上传 R2 → 流式返回进度与结果 URL；`Delete`：按 key 删 object
+- [x] 5.7 `plugin.toml`（`tts_generation = true` + config_schema JSON Schema）
+- [x] 5.8 `.github/workflows/release.yml`：tag 触发跨平台编译（linux/darwin × amd64/arm64）
+
+## 6. Tests & 收尾
+
+- [x] 6.1 `tests/test_tts_routes.py`：mock stub 流，断言进度事件 + frontmatter 写入 + 无插件 400
+- [x] 6.2 `tests/test_plugin_manager.py`：补 `get_tts_generator_stub` / `find_plugin_with_capability` 用例
+- [x] 6.3 `uv run pytest` + `uv run ruff check .` 通过
+- [ ] 6.4 端到端自测：装插件 → 编辑器生成一篇语音播报（需 MiMo/R2 凭据，留待用户验证）

--- a/proto/plugin.proto
+++ b/proto/plugin.proto
@@ -30,6 +30,18 @@ service ImageUploader {
 }
 
 // ============================================
+// Optional capability: TTS (text-to-speech)
+// ============================================
+
+service TTSGenerator {
+  // Server-streaming: plugin emits Progress messages while synthesizing,
+  // and a final Result carrying the public audio URL.
+  rpc Generate(TTSRequest) returns (stream TTSResponse);
+  // Delete a previously generated/hosted audio object.
+  rpc Delete(TTSDeleteRequest) returns (TTSDeleteResponse);
+}
+
+// ============================================
 // Messages
 // ============================================
 
@@ -88,6 +100,50 @@ message ImageDeleteRequest {
 }
 
 message ImageDeleteResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+// --- TTSGenerator messages ---
+
+message TTSRequest {
+  string text = 1;          // text to synthesize (article body, no frontmatter)
+  string voice = 2;         // voice id, e.g. "mimo_default"
+  string model = 3;         // e.g. "mimo-v2.5-tts"
+  float speed = 4;          // 0.5–2.0, 1.0 = normal
+  string format = 5;        // "mp3" (default) | "wav"
+  string language = 6;      // optional BCP-47 hint
+  string article_path = 7;  // article path for context (e.g. object key naming)
+}
+
+// A single streamed response: either a progress update or the final result.
+message TTSResponse {
+  oneof payload {
+    TTSProgress progress = 1;
+    TTSResult result = 2;
+  }
+}
+
+message TTSProgress {
+  string stage = 1;    // e.g. "synthesizing" | "uploading"
+  float percent = 2;   // 0.0–100.0
+  string message = 3;  // optional human-readable detail
+}
+
+message TTSResult {
+  bool success = 1;
+  string url = 2;              // public audio URL (e.g. Cloudflare R2)
+  float duration_seconds = 3;  // audio length, 0 if unknown
+  string audio_id = 4;         // provider-specific id for later Delete
+  string format = 5;           // actual delivered format, e.g. "mp3"
+  string message = 6;          // error detail when success=false
+}
+
+message TTSDeleteRequest {
+  string audio_id = 1;
+}
+
+message TTSDeleteResponse {
   bool success = 1;
   string message = 2;
 }

--- a/proto/plugin_pb2.py
+++ b/proto/plugin_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cplugin.proto\x12\x11hugo_admin.plugin\"\x07\n\x05\x45mpty\"\x92\x01\n\nPluginInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x0e\n\x06\x61uthor\x18\x04 \x01(\t\x12\x18\n\x10protocol_version\x18\x05 \x01(\t\x12\x14\n\x0c\x63\x61pabilities\x18\x06 \x03(\t\x12\x10\n\x08priority\x18\x07 \x01(\x05\"2\n\x0eHealthResponse\x12\x0f\n\x07healthy\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\"+\n\x14\x43onfigSchemaResponse\x12\x13\n\x0bschema_json\x18\x01 \x01(\t\"\'\n\x10SetConfigRequest\x12\x13\n\x0b\x63onfig_json\x18\x01 \x01(\t\"5\n\x11SetConfigResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\"l\n\x10ImageUploadChunk\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x11\n\tmime_type\x18\x03 \x01(\t\x12\x14\n\x0c\x61rticle_path\x18\x04 \x01(\t\x12\x0f\n\x07is_last\x18\x05 \x01(\x08\"V\n\x13ImageUploadResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0b\n\x03url\x18\x02 \x01(\t\x12\x10\n\x08image_id\x18\x03 \x01(\t\x12\x0f\n\x07message\x18\x04 \x01(\t\"&\n\x12ImageDeleteRequest\x12\x10\n\x08image_id\x18\x01 \x01(\t\"7\n\x13ImageDeleteResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t2\xca\x02\n\rPluginService\x12?\n\x04Info\x12\x18.hugo_admin.plugin.Empty\x1a\x1d.hugo_admin.plugin.PluginInfo\x12J\n\x0bHealthCheck\x12\x18.hugo_admin.plugin.Empty\x1a!.hugo_admin.plugin.HealthResponse\x12T\n\x0fGetConfigSchema\x12\x18.hugo_admin.plugin.Empty\x1a\'.hugo_admin.plugin.ConfigSchemaResponse\x12V\n\tSetConfig\x12#.hugo_admin.plugin.SetConfigRequest\x1a$.hugo_admin.plugin.SetConfigResponse2\xc1\x01\n\rImageUploader\x12W\n\x06Upload\x12#.hugo_admin.plugin.ImageUploadChunk\x1a&.hugo_admin.plugin.ImageUploadResponse(\x01\x12W\n\x06\x44\x65lete\x12%.hugo_admin.plugin.ImageDeleteRequest\x1a&.hugo_admin.plugin.ImageDeleteResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cplugin.proto\x12\x11hugo_admin.plugin\"\x07\n\x05\x45mpty\"\x92\x01\n\nPluginInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x0e\n\x06\x61uthor\x18\x04 \x01(\t\x12\x18\n\x10protocol_version\x18\x05 \x01(\t\x12\x14\n\x0c\x63\x61pabilities\x18\x06 \x03(\t\x12\x10\n\x08priority\x18\x07 \x01(\x05\"2\n\x0eHealthResponse\x12\x0f\n\x07healthy\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\"+\n\x14\x43onfigSchemaResponse\x12\x13\n\x0bschema_json\x18\x01 \x01(\t\"\'\n\x10SetConfigRequest\x12\x13\n\x0b\x63onfig_json\x18\x01 \x01(\t\"5\n\x11SetConfigResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\"l\n\x10ImageUploadChunk\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x11\n\tmime_type\x18\x03 \x01(\t\x12\x14\n\x0c\x61rticle_path\x18\x04 \x01(\t\x12\x0f\n\x07is_last\x18\x05 \x01(\x08\"V\n\x13ImageUploadResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0b\n\x03url\x18\x02 \x01(\t\x12\x10\n\x08image_id\x18\x03 \x01(\t\x12\x0f\n\x07message\x18\x04 \x01(\t\"&\n\x12ImageDeleteRequest\x12\x10\n\x08image_id\x18\x01 \x01(\t\"7\n\x13ImageDeleteResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\"\x7f\n\nTTSRequest\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\r\n\x05voice\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\r\n\x05speed\x18\x04 \x01(\x02\x12\x0e\n\x06\x66ormat\x18\x05 \x01(\t\x12\x10\n\x08language\x18\x06 \x01(\t\x12\x14\n\x0c\x61rticle_path\x18\x07 \x01(\t\"|\n\x0bTTSResponse\x12\x32\n\x08progress\x18\x01 \x01(\x0b\x32\x1e.hugo_admin.plugin.TTSProgressH\x00\x12.\n\x06result\x18\x02 \x01(\x0b\x32\x1c.hugo_admin.plugin.TTSResultH\x00\x42\t\n\x07payload\">\n\x0bTTSProgress\x12\r\n\x05stage\x18\x01 \x01(\t\x12\x0f\n\x07percent\x18\x02 \x01(\x02\x12\x0f\n\x07message\x18\x03 \x01(\t\"v\n\tTTSResult\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0b\n\x03url\x18\x02 \x01(\t\x12\x18\n\x10\x64uration_seconds\x18\x03 \x01(\x02\x12\x10\n\x08\x61udio_id\x18\x04 \x01(\t\x12\x0e\n\x06\x66ormat\x18\x05 \x01(\t\x12\x0f\n\x07message\x18\x06 \x01(\t\"$\n\x10TTSDeleteRequest\x12\x10\n\x08\x61udio_id\x18\x01 \x01(\t\"5\n\x11TTSDeleteResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t2\xca\x02\n\rPluginService\x12?\n\x04Info\x12\x18.hugo_admin.plugin.Empty\x1a\x1d.hugo_admin.plugin.PluginInfo\x12J\n\x0bHealthCheck\x12\x18.hugo_admin.plugin.Empty\x1a!.hugo_admin.plugin.HealthResponse\x12T\n\x0fGetConfigSchema\x12\x18.hugo_admin.plugin.Empty\x1a\'.hugo_admin.plugin.ConfigSchemaResponse\x12V\n\tSetConfig\x12#.hugo_admin.plugin.SetConfigRequest\x1a$.hugo_admin.plugin.SetConfigResponse2\xc1\x01\n\rImageUploader\x12W\n\x06Upload\x12#.hugo_admin.plugin.ImageUploadChunk\x1a&.hugo_admin.plugin.ImageUploadResponse(\x01\x12W\n\x06\x44\x65lete\x12%.hugo_admin.plugin.ImageDeleteRequest\x1a&.hugo_admin.plugin.ImageDeleteResponse2\xb0\x01\n\x0cTTSGenerator\x12K\n\x08Generate\x12\x1d.hugo_admin.plugin.TTSRequest\x1a\x1e.hugo_admin.plugin.TTSResponse0\x01\x12S\n\x06\x44\x65lete\x12#.hugo_admin.plugin.TTSDeleteRequest\x1a$.hugo_admin.plugin.TTSDeleteResponseb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -51,8 +51,22 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_IMAGEDELETEREQUEST']._serialized_end=622
   _globals['_IMAGEDELETERESPONSE']._serialized_start=624
   _globals['_IMAGEDELETERESPONSE']._serialized_end=679
-  _globals['_PLUGINSERVICE']._serialized_start=682
-  _globals['_PLUGINSERVICE']._serialized_end=1012
-  _globals['_IMAGEUPLOADER']._serialized_start=1015
-  _globals['_IMAGEUPLOADER']._serialized_end=1208
+  _globals['_TTSREQUEST']._serialized_start=681
+  _globals['_TTSREQUEST']._serialized_end=808
+  _globals['_TTSRESPONSE']._serialized_start=810
+  _globals['_TTSRESPONSE']._serialized_end=934
+  _globals['_TTSPROGRESS']._serialized_start=936
+  _globals['_TTSPROGRESS']._serialized_end=998
+  _globals['_TTSRESULT']._serialized_start=1000
+  _globals['_TTSRESULT']._serialized_end=1118
+  _globals['_TTSDELETEREQUEST']._serialized_start=1120
+  _globals['_TTSDELETEREQUEST']._serialized_end=1156
+  _globals['_TTSDELETERESPONSE']._serialized_start=1158
+  _globals['_TTSDELETERESPONSE']._serialized_end=1211
+  _globals['_PLUGINSERVICE']._serialized_start=1214
+  _globals['_PLUGINSERVICE']._serialized_end=1544
+  _globals['_IMAGEUPLOADER']._serialized_start=1547
+  _globals['_IMAGEUPLOADER']._serialized_end=1740
+  _globals['_TTSGENERATOR']._serialized_start=1743
+  _globals['_TTSGENERATOR']._serialized_end=1919
 # @@protoc_insertion_point(module_scope)

--- a/proto/plugin_pb2_grpc.py
+++ b/proto/plugin_pb2_grpc.py
@@ -368,3 +368,133 @@ class ImageUploader:
             timeout,
             metadata,
             _registered_method=True)
+
+
+class TTSGeneratorStub:
+    """============================================
+    Optional capability: TTS (text-to-speech)
+    ============================================
+
+    """
+
+    def __init__(self, channel):
+        """Constructor.
+
+        Args:
+            channel: A grpc.Channel.
+        """
+        self.Generate = channel.unary_stream(
+                '/hugo_admin.plugin.TTSGenerator/Generate',
+                request_serializer=plugin__pb2.TTSRequest.SerializeToString,
+                response_deserializer=plugin__pb2.TTSResponse.FromString,
+                _registered_method=True)
+        self.Delete = channel.unary_unary(
+                '/hugo_admin.plugin.TTSGenerator/Delete',
+                request_serializer=plugin__pb2.TTSDeleteRequest.SerializeToString,
+                response_deserializer=plugin__pb2.TTSDeleteResponse.FromString,
+                _registered_method=True)
+
+
+class TTSGeneratorServicer:
+    """============================================
+    Optional capability: TTS (text-to-speech)
+    ============================================
+
+    """
+
+    def Generate(self, request, context):
+        """Server-streaming: plugin emits Progress messages while synthesizing,
+        and a final Result carrying the public audio URL.
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def Delete(self, request, context):
+        """Delete a previously generated/hosted audio object.
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+
+def add_TTSGeneratorServicer_to_server(servicer, server):
+    rpc_method_handlers = {
+            'Generate': grpc.unary_stream_rpc_method_handler(
+                    servicer.Generate,
+                    request_deserializer=plugin__pb2.TTSRequest.FromString,
+                    response_serializer=plugin__pb2.TTSResponse.SerializeToString,
+            ),
+            'Delete': grpc.unary_unary_rpc_method_handler(
+                    servicer.Delete,
+                    request_deserializer=plugin__pb2.TTSDeleteRequest.FromString,
+                    response_serializer=plugin__pb2.TTSDeleteResponse.SerializeToString,
+            ),
+    }
+    generic_handler = grpc.method_handlers_generic_handler(
+            'hugo_admin.plugin.TTSGenerator', rpc_method_handlers)
+    server.add_generic_rpc_handlers((generic_handler,))
+    server.add_registered_method_handlers('hugo_admin.plugin.TTSGenerator', rpc_method_handlers)
+
+
+ # This class is part of an EXPERIMENTAL API.
+class TTSGenerator:
+    """============================================
+    Optional capability: TTS (text-to-speech)
+    ============================================
+
+    """
+
+    @staticmethod
+    def Generate(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_stream(
+            request,
+            target,
+            '/hugo_admin.plugin.TTSGenerator/Generate',
+            plugin__pb2.TTSRequest.SerializeToString,
+            plugin__pb2.TTSResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def Delete(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/hugo_admin.plugin.TTSGenerator/Delete',
+            plugin__pb2.TTSDeleteRequest.SerializeToString,
+            plugin__pb2.TTSDeleteResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -21,6 +21,7 @@ from .server_routes import register_server_routes
 from .settings_routes import register_settings_routes
 from .socketio_routes import register_socketio_handlers
 from .theme_routes import register_theme_routes
+from .tts_routes import register_tts_routes
 
 __all__ = [
     "register_page_routes",
@@ -40,4 +41,5 @@ __all__ = [
     "install_auth_guard",
     "register_theme_routes",
     "register_config_routes",
+    "register_tts_routes",
 ]

--- a/routes/image_routes.py
+++ b/routes/image_routes.py
@@ -23,16 +23,7 @@ def _try_plugin_upload(registry, file_storage, article_path):
         return None
 
     # Find a running plugin with image_upload capability
-    target = None
-    for info in plugin_manager.list_plugins():
-        if (
-            info.get("status") == "running"
-            and info.get("enabled")
-            and "image_upload" in info.get("capabilities", [])
-        ):
-            target = info
-            break
-
+    target = plugin_manager.find_plugin_with_capability("image_upload")
     if target is None:
         return None
 

--- a/routes/plugin_routes.py
+++ b/routes/plugin_routes.py
@@ -210,15 +210,6 @@ def register_plugin_routes(plugin_manager: PluginManager, socketio=None):
                 404,
             )
 
-        req = plugin_pb2.TTSRequest(
-            text=text,
-            voice=data.get("voice", "") or "",
-            model=data.get("model", "") or "",
-            speed=float(data.get("speed", 1.0)),
-            format=data.get("format", "") or "",
-            language=data.get("language", "") or "",
-            article_path=data.get("article_path", "") or "",
-        )
         event_scope = data.get("event_scope", "")
 
         def _emit(event: str, payload: dict):
@@ -230,6 +221,19 @@ def register_plugin_routes(plugin_manager: PluginManager, socketio=None):
                 logger.exception("Socket emit failed for %s", event)
 
         try:
+            # 构造放 try 内：非法 speed（null/"abc"）会抛 TypeError/ValueError，
+            # 返回 JSON 400 而非逸出成 HTML 500。
+            raw_speed = data.get("speed", 1.0)
+            speed = float(raw_speed) if raw_speed is not None else 1.0
+            req = plugin_pb2.TTSRequest(
+                text=text,
+                voice=data.get("voice", "") or "",
+                model=data.get("model", "") or "",
+                speed=speed,
+                format=data.get("format", "") or "",
+                language=data.get("language", "") or "",
+                article_path=data.get("article_path", "") or "",
+            )
             result = None
             for resp in stub.Generate(req, timeout=300):
                 which = resp.WhichOneof("payload")
@@ -267,6 +271,9 @@ def register_plugin_routes(plugin_manager: PluginManager, socketio=None):
                     "message": result.message,
                 }
             )
+        except (TypeError, ValueError) as e:
+            # 非法 speed（null/"abc" 等）—— 客户端错误，返回 400
+            return jsonify({"success": False, "message": f"无效的参数: {e}"}), 400
         except Exception as e:
             logger.error("TTS via plugin %s failed: %s", name, e)
             return jsonify({"success": False, "message": f"TTS failed: {e}"}), 500

--- a/routes/plugin_routes.py
+++ b/routes/plugin_routes.py
@@ -14,8 +14,13 @@ logger = logging.getLogger(__name__)
 bp = Blueprint("plugins", __name__)
 
 
-def register_plugin_routes(plugin_manager: PluginManager):
-    """Register all plugin REST endpoints and capability proxy routes."""
+def register_plugin_routes(plugin_manager: PluginManager, socketio=None):
+    """Register all plugin REST endpoints and capability proxy routes.
+
+    ``socketio`` is optional: when provided, the TTS capability proxy forwards
+    streaming progress events to the client; without it progress is silently
+    consumed (only the final result is returned).
+    """
 
     # ---- Plugin Management ----
 
@@ -173,6 +178,116 @@ def register_plugin_routes(plugin_manager: PluginManager):
             return jsonify({"success": resp.success, "message": resp.message})
         except Exception as e:
             logger.error("Image delete via plugin %s failed: %s", name, e)
+            return jsonify({"success": False, "message": f"Delete failed: {e}"}), 500
+
+    # ---- Capability Proxy: TTS Generation ----
+
+    @bp.route("/api/plugins/<name>/tts/generate", methods=["POST"])
+    def generate_tts_via_plugin(name):
+        """Proxy TTS generation to a plugin's TTSGenerator gRPC service.
+
+        Iterates the server-streaming response. ``progress`` messages are
+        forwarded to the client via Socket.IO (event ``tts.progress``) when a
+        socketio instance is wired in; the final ``result`` is returned as JSON.
+        """
+        data = request.get_json(silent=True) or {}
+        text = data.get("text", "")
+        if not text:
+            return jsonify({"success": False, "message": "缺少待合成文本"}), 400
+
+        stub = plugin_manager.get_tts_generator_stub(name)
+        if stub is None:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": (
+                            f"Plugin {name} not running"
+                            " or does not support tts_generation"
+                        ),
+                    }
+                ),
+                404,
+            )
+
+        req = plugin_pb2.TTSRequest(
+            text=text,
+            voice=data.get("voice", "") or "",
+            model=data.get("model", "") or "",
+            speed=float(data.get("speed", 1.0)),
+            format=data.get("format", "") or "",
+            language=data.get("language", "") or "",
+            article_path=data.get("article_path", "") or "",
+        )
+        event_scope = data.get("event_scope", "")
+
+        def _emit(event: str, payload: dict):
+            if socketio is None:
+                return
+            try:
+                socketio.emit(event, {"scope": event_scope, **payload})
+            except Exception:
+                logger.exception("Socket emit failed for %s", event)
+
+        try:
+            result = None
+            for resp in stub.Generate(req, timeout=300):
+                which = resp.WhichOneof("payload")
+                if which == "progress":
+                    p = resp.progress
+                    _emit(
+                        "tts.progress",
+                        {
+                            "stage": p.stage,
+                            "percent": p.percent,
+                            "message": p.message,
+                        },
+                    )
+                elif which == "result":
+                    result = resp.result
+
+            if result is None:
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "message": "插件未返回 TTS 结果",
+                        }
+                    ),
+                    502,
+                )
+
+            return jsonify(
+                {
+                    "success": result.success,
+                    "url": result.url,
+                    "duration_seconds": result.duration_seconds,
+                    "audio_id": result.audio_id,
+                    "format": result.format,
+                    "message": result.message,
+                }
+            )
+        except Exception as e:
+            logger.error("TTS via plugin %s failed: %s", name, e)
+            return jsonify({"success": False, "message": f"TTS failed: {e}"}), 500
+
+    @bp.route("/api/plugins/<name>/tts/<audio_id>", methods=["DELETE"])
+    def delete_tts_via_plugin(name, audio_id):
+        """Proxy TTS audio deletion to a plugin's TTSGenerator gRPC service."""
+        stub = plugin_manager.get_tts_generator_stub(name)
+        if stub is None:
+            return (
+                jsonify({"success": False, "message": f"Plugin {name} not running"}),
+                404,
+            )
+
+        try:
+            resp = stub.Delete(
+                plugin_pb2.TTSDeleteRequest(audio_id=audio_id), timeout=30
+            )
+            return jsonify({"success": resp.success, "message": resp.message})
+        except Exception as e:
+            logger.error("TTS delete via plugin %s failed: %s", name, e)
             return jsonify({"success": False, "message": f"Delete failed: {e}"}), 500
 
     return bp

--- a/routes/tts_routes.py
+++ b/routes/tts_routes.py
@@ -114,7 +114,7 @@ def _run_tts_with_emits(
     if result.audio_id:
         fm[FM_AUDIO_ID] = result.audio_id
 
-    save_ok, save_msg, _new_mtime = post_service.save_file(
+    save_ok, save_msg, new_mtime = post_service.save_file(
         article_path, body, frontmatter_data=fm, expected_mtime=expected_mtime
     )
 
@@ -141,6 +141,8 @@ def _run_tts_with_emits(
             "duration_seconds": result.duration_seconds,
             "format": result.format,
             "audio_id": result.audio_id,
+            # 回传新 mtime，前端据此刷新 fileMtime，避免下次手动保存触发假冲突
+            "mtime": new_mtime,
         },
     )
 
@@ -164,13 +166,17 @@ def register_tts_routes(registry):
                 # config_schema 可能声明可选音色列表
                 try:
                     schema = plugin_manager.get_config_schema(name) or {}
-                    voices = (schema.get("properties") or {}).get(
-                        "voices", {}
-                    ).get("items", {}).get("enum", [])
+                    voices = (
+                        (schema.get("properties") or {})
+                        .get("voices", {})
+                        .get("items", {})
+                        .get("enum", [])
+                    )
                 except Exception:  # noqa: BLE001
                     voices = []
-        return jsonify({"success": True, "available": available, "plugin": name,
-                        "voices": voices})
+        return jsonify(
+            {"success": True, "available": available, "plugin": name, "voices": voices}
+        )
 
     @bp.route("/api/article/tts", methods=["POST"])
     def generate_article_tts():
@@ -248,9 +254,7 @@ def register_tts_routes(registry):
             socketio,
             event_scope,
         )
-        return jsonify(
-            {"success": True, "pending": True, "event_scope": event_scope}
-        )
+        return jsonify({"success": True, "pending": True, "event_scope": event_scope})
 
     @bp.route("/api/article/tts", methods=["DELETE"])
     def delete_article_tts():
@@ -273,11 +277,16 @@ def register_tts_routes(registry):
         for k in (FM_AUDIO, FM_AUDIO_DURATION, FM_AUDIO_FORMAT):
             fm.pop(k, None)
 
-        save_ok, save_msg, _new_mtime = registry.post_service.save_file(
+        save_ok, save_msg, new_mtime = registry.post_service.save_file(
             article_path, body, frontmatter_data=fm
         )
         if not save_ok:
-            return jsonify({"success": False, "message": f"清除 audio 字段失败: {save_msg}"}), 500
+            return (
+                jsonify(
+                    {"success": False, "message": f"清除 audio 字段失败: {save_msg}"}
+                ),
+                500,
+            )
 
         # 通知插件删除托管音频（若有凭证）
         if audio_id:
@@ -291,9 +300,18 @@ def register_tts_routes(registry):
                             timeout=30,
                         )
                     except Exception as e:  # noqa: BLE001
-                        logger.warning("插件删除托管音频失败（已清 frontmatter）: %s", e)
+                        logger.warning(
+                            "插件删除托管音频失败（已清 frontmatter）: %s", e
+                        )
 
-        return jsonify({"success": True, "message": "已删除语音"})
+        return jsonify(
+            {
+                "success": True,
+                "message": "已删除语音",
+                # 回传新 mtime，前端据此刷新 fileMtime，避免下次保存触发假冲突
+                "mtime": new_mtime,
+            }
+        )
 
     return bp
 

--- a/routes/tts_routes.py
+++ b/routes/tts_routes.py
@@ -1,0 +1,305 @@
+# coding: utf-8
+"""
+文章级 TTS（语音播报）路由。
+
+在编辑器中为一篇文章生成语音：读取正文（剥离 frontmatter）→ 调用带
+``tts_generation`` 能力的插件 → 后台任务经 Socket.IO 上报进度 → 成功后用
+乐观锁把 audio URL 写回 frontmatter。复刻 article_import_service 的后台
+任务 + 进度事件模式。
+"""
+
+import logging
+import uuid
+
+import grpc
+from flask import Blueprint, jsonify, request
+
+from proto import plugin_pb2
+
+logger = logging.getLogger(__name__)
+
+# 该插件能力的名字（与 proto / plugin.toml 中的 capabilities 一致）
+TTS_CAPABILITY = "tts_generation"
+
+# 写回 frontmatter 时使用的字段名
+FM_AUDIO = "audio"
+FM_AUDIO_DURATION = "audio_duration_seconds"
+FM_AUDIO_FORMAT = "audio_format"
+FM_AUDIO_ID = "_tts_audio_id"  # 非公开字段，作为删除托管音频的凭证
+
+
+def _resolve_plugin(plugin_manager):
+    """找到运行中的 TTS 插件，返回 (plugin_info, stub) 或 (None, None)。"""
+    target = plugin_manager.find_plugin_with_capability(TTS_CAPABILITY)
+    if target is None:
+        return None, None
+    stub = plugin_manager.get_tts_generator_stub(target["name"])
+    return target, stub
+
+
+def _run_tts_with_emits(
+    post_service,
+    plugin_manager,
+    article_path,
+    text,
+    options,
+    expected_mtime,
+    socketio,
+    event_scope,
+) -> None:
+    """后台任务：调插件生成语音并写回 frontmatter，全程经 Socket.IO 上报。"""
+
+    def emit_event(event: str, payload: dict) -> None:
+        try:
+            socketio.emit(event, {"scope": event_scope, **payload})
+        except Exception:
+            logger.exception("Socket emit failed for %s", event)
+
+    target, stub = _resolve_plugin(plugin_manager)
+    if stub is None:
+        emit_event("tts.failed", {"message": "未找到支持 tts_generation 的插件"})
+        return
+
+    req = plugin_pb2.TTSRequest(
+        text=text,
+        voice=options.get("voice", "") or "",
+        model=options.get("model", "") or "",
+        speed=float(options.get("speed", 1.0)),
+        format=options.get("format", "") or "",
+        language=options.get("language", "") or "",
+        article_path=article_path or "",
+    )
+
+    try:
+        result = None
+        for resp in stub.Generate(req, timeout=300):
+            which = resp.WhichOneof("payload")
+            if which == "progress":
+                p = resp.progress
+                emit_event(
+                    "tts.progress",
+                    {
+                        "stage": p.stage,
+                        "percent": p.percent,
+                        "message": p.message,
+                    },
+                )
+            elif which == "result":
+                result = resp.result
+    except grpc.RpcError as e:
+        emit_event("tts.failed", {"message": f"插件调用失败: {e.details() or e}"})
+        return
+    except Exception as e:  # noqa: BLE001 — 后台任务不能崩
+        emit_event("tts.failed", {"message": f"生成失败: {e}"})
+        return
+
+    if result is None or not result.success:
+        emit_event(
+            "tts.failed",
+            {"message": (result.message if result else "插件未返回结果")},
+        )
+        return
+
+    # 写回 frontmatter（乐观锁）
+    ok, body, fm, _mtime = post_service.read_file_with_frontmatter(article_path)
+    if not ok:
+        emit_event("tts.failed", {"message": "读取文章失败，无法写回 audio 字段"})
+        return
+
+    fm[FM_AUDIO] = result.url
+    if result.duration_seconds > 0:
+        fm[FM_AUDIO_DURATION] = result.duration_seconds
+    if result.format:
+        fm[FM_AUDIO_FORMAT] = result.format
+    if result.audio_id:
+        fm[FM_AUDIO_ID] = result.audio_id
+
+    save_ok, save_msg, _new_mtime = post_service.save_file(
+        article_path, body, frontmatter_data=fm, expected_mtime=expected_mtime
+    )
+
+    if not save_ok:
+        # 乐观锁冲突：save_msg 是一个 dict
+        if isinstance(save_msg, dict) and save_msg.get("conflict"):
+            emit_event(
+                "tts.conflict",
+                {
+                    "message": "文章已被修改，请保存后重试",
+                    "current_mtime": save_msg.get("current_mtime"),
+                    "url": result.url,
+                    "audio_id": result.audio_id,
+                },
+            )
+        else:
+            emit_event("tts.failed", {"message": f"写入 frontmatter 失败: {save_msg}"})
+        return
+
+    emit_event(
+        "tts.done",
+        {
+            "url": result.url,
+            "duration_seconds": result.duration_seconds,
+            "format": result.format,
+            "audio_id": result.audio_id,
+        },
+    )
+
+
+def register_tts_routes(registry):
+    """注册文章级 TTS 路由。"""
+    bp = Blueprint("tts", __name__)
+
+    @bp.route("/api/article/tts/status", methods=["GET"])
+    def tts_status():
+        """返回 TTS 能力是否可用（前端据此显隐按钮）。"""
+        plugin_manager = getattr(registry, "plugin_manager", None)
+        available = False
+        name = None
+        voices: list[str] = []
+        if plugin_manager is not None:
+            target = plugin_manager.find_plugin_with_capability(TTS_CAPABILITY)
+            if target is not None:
+                available = True
+                name = target["name"]
+                # config_schema 可能声明可选音色列表
+                try:
+                    schema = plugin_manager.get_config_schema(name) or {}
+                    voices = (schema.get("properties") or {}).get(
+                        "voices", {}
+                    ).get("items", {}).get("enum", [])
+                except Exception:  # noqa: BLE001
+                    voices = []
+        return jsonify({"success": True, "available": available, "plugin": name,
+                        "voices": voices})
+
+    @bp.route("/api/article/tts", methods=["POST"])
+    def generate_article_tts():
+        """为一篇文章生成语音播报。
+
+        入参: {article_path, voice?, model?, speed?, format?, language?, text?}
+        - 若提供 ``text`` 则直接用它；否则读取文章正文（剥离 frontmatter）。
+        立即返回 event_scope，进度与结果经 Socket.IO（tts.*）上报。
+        """
+        data = request.get_json(silent=True) or {}
+        article_path = data.get("article_path")
+        if not article_path:
+            return jsonify({"success": False, "message": "缺少文章路径"}), 400
+
+        plugin_manager = getattr(registry, "plugin_manager", None)
+        if plugin_manager is None:
+            return jsonify({"success": False, "message": "插件系统未初始化"}), 400
+
+        target, stub = _resolve_plugin(plugin_manager)
+        if target is None or stub is None:
+            return (
+                jsonify(
+                    {"success": False, "message": "未找到支持 tts_generation 的插件"}
+                ),
+                400,
+            )
+
+        text = data.get("text")
+        expected_mtime = None
+        if not text:
+            ok, body, _fm, mtime = registry.post_service.read_file_with_frontmatter(
+                article_path
+            )
+            if not ok:
+                return jsonify({"success": False, "message": "读取文章失败"}), 400
+            text = body
+            expected_mtime = mtime
+
+        text = (text or "").strip()
+        if not text:
+            return jsonify({"success": False, "message": "文章内容为空"}), 400
+
+        socketio = getattr(registry, "socketio", None)
+        event_scope = str(uuid.uuid4())
+        options = {
+            k: data.get(k)
+            for k in ("voice", "model", "speed", "format", "language")
+            if data.get(k) is not None
+        }
+
+        if socketio is None:
+            # 无 Socket.IO 时退化为同步执行（主要供脚本/测试）
+            _run_tts_with_emits(
+                registry.post_service,
+                plugin_manager,
+                article_path,
+                text,
+                options,
+                expected_mtime,
+                _NoopSocket(),
+                event_scope,
+            )
+            return jsonify(
+                {"success": True, "pending": False, "event_scope": event_scope}
+            )
+
+        socketio.start_background_task(
+            _run_tts_with_emits,
+            registry.post_service,
+            plugin_manager,
+            article_path,
+            text,
+            options,
+            expected_mtime,
+            socketio,
+            event_scope,
+        )
+        return jsonify(
+            {"success": True, "pending": True, "event_scope": event_scope}
+        )
+
+    @bp.route("/api/article/tts", methods=["DELETE"])
+    def delete_article_tts():
+        """删除文章的语音：清 frontmatter 音频字段，并通知插件删托管 object。
+
+        入参: {article_path}
+        """
+        data = request.get_json(silent=True) or {}
+        article_path = data.get("article_path")
+        if not article_path:
+            return jsonify({"success": False, "message": "缺少文章路径"}), 400
+
+        ok, body, fm, _mtime = registry.post_service.read_file_with_frontmatter(
+            article_path
+        )
+        if not ok:
+            return jsonify({"success": False, "message": "读取文章失败"}), 400
+
+        audio_id = fm.pop(FM_AUDIO_ID, "")
+        for k in (FM_AUDIO, FM_AUDIO_DURATION, FM_AUDIO_FORMAT):
+            fm.pop(k, None)
+
+        save_ok, save_msg, _new_mtime = registry.post_service.save_file(
+            article_path, body, frontmatter_data=fm
+        )
+        if not save_ok:
+            return jsonify({"success": False, "message": f"清除 audio 字段失败: {save_msg}"}), 500
+
+        # 通知插件删除托管音频（若有凭证）
+        if audio_id:
+            plugin_manager = getattr(registry, "plugin_manager", None)
+            if plugin_manager is not None:
+                target, stub = _resolve_plugin(plugin_manager)
+                if stub is not None:
+                    try:
+                        stub.Delete(
+                            plugin_pb2.TTSDeleteRequest(audio_id=audio_id),
+                            timeout=30,
+                        )
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning("插件删除托管音频失败（已清 frontmatter）: %s", e)
+
+        return jsonify({"success": True, "message": "已删除语音"})
+
+    return bp
+
+
+class _NoopSocket:
+    """无 Socket.IO 时的空实现（同步路径用）。"""
+
+    def emit(self, *_args, **_kwargs):
+        return None

--- a/services/plugin_manager.py
+++ b/services/plugin_manager.py
@@ -375,6 +375,33 @@ class PluginManager:
             return plugin_pb2_grpc.ImageUploaderStub(state.channel)
         return None
 
+    def get_tts_generator_stub(
+        self, name: str
+    ) -> Optional[plugin_pb2_grpc.TTSGeneratorStub]:
+        """Get the TTSGenerator gRPC stub for a running plugin."""
+        state = self._plugins.get(name)
+        if state and state.enabled and state.channel:
+            return plugin_pb2_grpc.TTSGeneratorStub(state.channel)
+        return None
+
+    def find_plugin_with_capability(
+        self, capability: str
+    ) -> Optional[dict[str, Any]]:
+        """Return the first running+enabled plugin info declaring a capability.
+
+        Used by article-integration layers (image upload, TTS, ...) to locate
+        the active plugin for a capability without repeating the scan loop.
+        Returns the plugin info dict (as produced by ``list_plugins``) or None.
+        """
+        for info in self.list_plugins():
+            if (
+                info.get("status") == "running"
+                and info.get("enabled")
+                and capability in info.get("capabilities", [])
+            ):
+                return info
+        return None
+
     # ---- Config ----
 
     def get_plugin_config(self, name: str) -> dict[str, Any]:

--- a/services/plugin_manager.py
+++ b/services/plugin_manager.py
@@ -384,9 +384,7 @@ class PluginManager:
             return plugin_pb2_grpc.TTSGeneratorStub(state.channel)
         return None
 
-    def find_plugin_with_capability(
-        self, capability: str
-    ) -> Optional[dict[str, Any]]:
+    def find_plugin_with_capability(self, capability: str) -> Optional[dict[str, Any]]:
         """Return the first running+enabled plugin info declaring a capability.
 
         Used by article-integration layers (image upload, TTS, ...) to locate

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -629,6 +629,50 @@ class TestPluginManagerStubs:
         pm._plugins["p"] = _make_state(name="p", enabled=False, channel=None)
         assert pm.get_image_uploader_stub("p") is None
 
+    @patch("services.plugin_manager.plugin_pb2_grpc")
+    def test_get_tts_generator_stub_running(self, mock_pb2_grpc):
+        """运行中的插件应创建 TTSGeneratorStub。"""
+        pm = PluginManager()
+        channel = MagicMock()
+        pm._plugins["p"] = _make_state(name="p", enabled=True, channel=channel)
+
+        mock_stub = MagicMock()
+        mock_pb2_grpc.TTSGeneratorStub.return_value = mock_stub
+
+        result = pm.get_tts_generator_stub("p")
+        assert result is mock_stub
+        mock_pb2_grpc.TTSGeneratorStub.assert_called_once_with(channel)
+
+    def test_get_tts_generator_stub_stopped(self):
+        """已停止的插件应返回 None。"""
+        pm = PluginManager()
+        pm._plugins["p"] = _make_state(name="p", enabled=False, channel=None)
+        assert pm.get_tts_generator_stub("p") is None
+
+    def test_find_plugin_with_capability_match(self):
+        """应返回第一个声明该能力且运行中的插件。"""
+        pm = PluginManager()
+        pm._plugins["a"] = _make_state(name="a", enabled=True, status="running")
+        pm._plugins["a"].manifest.capabilities = ["tts_generation"]
+        # list_plugins 从 manifest 读 capabilities
+        found = pm.find_plugin_with_capability("tts_generation")
+        assert found is not None
+        assert found["name"] == "a"
+
+    def test_find_plugin_with_capability_no_match(self):
+        """无匹配能力时返回 None。"""
+        pm = PluginManager()
+        pm._plugins["a"] = _make_state(name="a", enabled=True, status="running")
+        pm._plugins["a"].manifest.capabilities = ["image_upload"]
+        assert pm.find_plugin_with_capability("tts_generation") is None
+
+    def test_find_plugin_with_capability_skips_disabled(self):
+        """已停用插件即便声明能力也不返回。"""
+        pm = PluginManager()
+        pm._plugins["a"] = _make_state(name="a", enabled=False, status="stopped")
+        pm._plugins["a"].manifest.capabilities = ["tts_generation"]
+        assert pm.find_plugin_with_capability("tts_generation") is None
+
 
 class TestPluginManagerConfig:
     """PluginManager config 操作测试。"""

--- a/tests/test_tts_routes.py
+++ b/tests/test_tts_routes.py
@@ -15,11 +15,10 @@ from routes.tts_routes import (
     FM_AUDIO,
     FM_AUDIO_DURATION,
     FM_AUDIO_ID,
-    register_tts_routes,
     _run_tts_with_emits,
+    register_tts_routes,
 )
 from services.post_service import PostService
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -29,7 +28,9 @@ from services.post_service import PostService
 def _make_tts_responses(success=True, url="https://r2.example.com/a.mp3"):
     """构造一个 TTSResponse 迭代器：一条 progress + 一条 result。"""
     progress = plugin_pb2.TTSResponse(
-        progress=plugin_pb2.TTSProgress(stage="synthesizing", percent=50.0, message="ok")
+        progress=plugin_pb2.TTSProgress(
+            stage="synthesizing", percent=50.0, message="ok"
+        )
     )
     result = plugin_pb2.TTSResponse(
         result=plugin_pb2.TTSResult(
@@ -109,6 +110,8 @@ class TestRunTtsWithEmits:
         assert events[0][0] == "tts.progress"
         done = [e for e in events if e[0] == "tts.done"]
         assert done and done[0][1]["url"] == "https://r2.example.com/a.mp3"
+        # done 事件必须回传新 mtime（mtime 一致性，见 design Decision 8）
+        assert done[0][1]["mtime"], "tts.done 必须携带 mtime"
 
     def test_plugin_missing_emits_failed(self, temp_setup):
         svc, _article, rel = temp_setup
@@ -122,9 +125,7 @@ class TestRunTtsWithEmits:
             def emit(self, event, payload):
                 events.append((event, payload))
 
-        _run_tts_with_emits(
-            svc, plugin_manager, rel, "x", {}, 0.0, Sock(), "scope-2"
-        )
+        _run_tts_with_emits(svc, plugin_manager, rel, "x", {}, 0.0, Sock(), "scope-2")
         failed = [e for e in events if e[0] == "tts.failed"]
         assert failed
         # frontmatter 未被改动
@@ -145,9 +146,7 @@ class TestRunTtsWithEmits:
             def emit(self, event, payload):
                 events.append((event, payload))
 
-        _run_tts_with_emits(
-            svc, plugin_manager, rel, "x", {}, 0.0, Sock(), "scope-3"
-        )
+        _run_tts_with_emits(svc, plugin_manager, rel, "x", {}, 0.0, Sock(), "scope-3")
         failed = [e for e in events if e[0] == "tts.failed"]
         assert failed and "boom" in failed[0][1]["message"]
 
@@ -166,9 +165,7 @@ class TestRunTtsWithEmits:
                 events.append((event, payload))
 
         # 用一个陈旧的 expected_mtime（明显偏离真实值）触发冲突
-        _run_tts_with_emits(
-            svc, plugin_manager, rel, "x", {}, 1.0, Sock(), "scope-4"
-        )
+        _run_tts_with_emits(svc, plugin_manager, rel, "x", {}, 1.0, Sock(), "scope-4")
         conflict = [e for e in events if e[0] == "tts.conflict"]
         assert conflict
         # 文件未被覆盖（仍无 audio 字段）
@@ -268,6 +265,10 @@ class TestDeleteRoute:
                 json={"article_path": "post/demo/index.md"},
             )
         assert resp.status_code == 200
+        data = resp.get_json()
+        # 删除响应必须回传新 mtime（mtime 一致性，见 design Decision 8）
+        assert data["success"] is True
+        assert data["mtime"], "delete 响应必须携带 mtime"
         _ok, _body, fm2, _ = svc.read_file_with_frontmatter("post/demo/index.md")
         assert FM_AUDIO not in fm2
         assert FM_AUDIO_ID not in fm2

--- a/tests/test_tts_routes.py
+++ b/tests/test_tts_routes.py
@@ -1,0 +1,275 @@
+# coding: utf-8 -*-
+"""
+文章级 TTS 路由 + 后台任务单元测试。
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from proto import plugin_pb2
+from routes.tts_routes import (
+    FM_AUDIO,
+    FM_AUDIO_DURATION,
+    FM_AUDIO_ID,
+    register_tts_routes,
+    _run_tts_with_emits,
+)
+from services.post_service import PostService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_tts_responses(success=True, url="https://r2.example.com/a.mp3"):
+    """构造一个 TTSResponse 迭代器：一条 progress + 一条 result。"""
+    progress = plugin_pb2.TTSResponse(
+        progress=plugin_pb2.TTSProgress(stage="synthesizing", percent=50.0, message="ok")
+    )
+    result = plugin_pb2.TTSResponse(
+        result=plugin_pb2.TTSResult(
+            success=success,
+            url=url,
+            duration_seconds=12.5,
+            audio_id="key-abc",
+            format="mp3",
+            message="" if success else "boom",
+        )
+    )
+    return [progress, result]
+
+
+@pytest.fixture
+def temp_setup():
+    """临时 content 目录 + PostService + 一篇文章。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        content_dir = Path(tmp)
+        svc = PostService(content_dir, use_cache=False)
+        article = content_dir / "post" / "demo" / "index.md"
+        article.parent.mkdir(parents=True)
+        article.write_text(
+            "---\ntitle: Demo\ndraft: true\n---\n\n这是一段正文。\n",
+            encoding="utf-8",
+        )
+        yield svc, article, "post/demo/index.md"
+
+
+@pytest.fixture
+def app_and_registry(temp_setup):
+    """Flask test app + 一个 mock registry（带 post_service）。"""
+    svc, _article, _rel = temp_setup
+    registry = MagicMock()
+    registry.post_service = svc
+    registry.socketio = None  # 走同步路径（_NoopSocket）
+    registry.plugin_manager = MagicMock()
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(register_tts_routes(registry))
+    yield app, registry, svc
+
+
+# ---------------------------------------------------------------------------
+# _run_tts_with_emits —— 后台任务核心逻辑
+# ---------------------------------------------------------------------------
+
+
+class TestRunTtsWithEmits:
+    def test_success_writes_frontmatter(self, temp_setup):
+        svc, _article, rel = temp_setup
+        # 读真实 mtime，模拟路由层读取文章时的快照
+        _ok, _body, _fm, mtime = svc.read_file_with_frontmatter(rel)
+        plugin_manager = MagicMock()
+        stub = MagicMock()
+        stub.Generate.return_value = iter(_make_tts_responses())
+        plugin_manager.find_plugin_with_capability.return_value = {"name": "tts-gen"}
+        plugin_manager.get_tts_generator_stub.return_value = stub
+
+        events = []
+
+        class Sock:
+            def emit(self, event, payload):
+                events.append((event, payload))
+
+        _run_tts_with_emits(
+            svc, plugin_manager, rel, "朗读文本", {}, mtime, Sock(), "scope-1"
+        )
+
+        # 写回 frontmatter
+        ok, body, fm, _mtime = svc.read_file_with_frontmatter(rel)
+        assert ok
+        assert fm[FM_AUDIO] == "https://r2.example.com/a.mp3"
+        assert fm[FM_AUDIO_DURATION] == 12.5
+        assert fm[FM_AUDIO_ID] == "key-abc"
+        # 进度 + done 事件
+        assert events[0][0] == "tts.progress"
+        done = [e for e in events if e[0] == "tts.done"]
+        assert done and done[0][1]["url"] == "https://r2.example.com/a.mp3"
+
+    def test_plugin_missing_emits_failed(self, temp_setup):
+        svc, _article, rel = temp_setup
+        plugin_manager = MagicMock()
+        plugin_manager.find_plugin_with_capability.return_value = None
+        plugin_manager.get_tts_generator_stub.return_value = None
+
+        events = []
+
+        class Sock:
+            def emit(self, event, payload):
+                events.append((event, payload))
+
+        _run_tts_with_emits(
+            svc, plugin_manager, rel, "x", {}, 0.0, Sock(), "scope-2"
+        )
+        failed = [e for e in events if e[0] == "tts.failed"]
+        assert failed
+        # frontmatter 未被改动
+        _ok, _body, fm, _ = svc.read_file_with_frontmatter(rel)
+        assert FM_AUDIO not in fm
+
+    def test_plugin_returns_failure_emits_failed(self, temp_setup):
+        svc, _article, rel = temp_setup
+        plugin_manager = MagicMock()
+        stub = MagicMock()
+        stub.Generate.return_value = iter(_make_tts_responses(success=False))
+        plugin_manager.find_plugin_with_capability.return_value = {"name": "tts-gen"}
+        plugin_manager.get_tts_generator_stub.return_value = stub
+
+        events = []
+
+        class Sock:
+            def emit(self, event, payload):
+                events.append((event, payload))
+
+        _run_tts_with_emits(
+            svc, plugin_manager, rel, "x", {}, 0.0, Sock(), "scope-3"
+        )
+        failed = [e for e in events if e[0] == "tts.failed"]
+        assert failed and "boom" in failed[0][1]["message"]
+
+    def test_conflict_emits_conflict(self, temp_setup):
+        svc, article, rel = temp_setup
+        plugin_manager = MagicMock()
+        stub = MagicMock()
+        stub.Generate.return_value = iter(_make_tts_responses())
+        plugin_manager.find_plugin_with_capability.return_value = {"name": "tts-gen"}
+        plugin_manager.get_tts_generator_stub.return_value = stub
+
+        events = []
+
+        class Sock:
+            def emit(self, event, payload):
+                events.append((event, payload))
+
+        # 用一个陈旧的 expected_mtime（明显偏离真实值）触发冲突
+        _run_tts_with_emits(
+            svc, plugin_manager, rel, "x", {}, 1.0, Sock(), "scope-4"
+        )
+        conflict = [e for e in events if e[0] == "tts.conflict"]
+        assert conflict
+        # 文件未被覆盖（仍无 audio 字段）
+        _ok, _body, fm, _ = svc.read_file_with_frontmatter(rel)
+        assert FM_AUDIO not in fm
+
+
+# ---------------------------------------------------------------------------
+# HTTP 路由
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateRoute:
+    def test_no_plugin_returns_400(self, app_and_registry):
+        app, registry, _svc = app_and_registry
+        registry.plugin_manager.find_plugin_with_capability.return_value = None
+        registry.plugin_manager.get_tts_generator_stub.return_value = None
+        with app.test_client() as client:
+            resp = client.post(
+                "/api/article/tts",
+                json={"article_path": "post/demo/index.md"},
+            )
+        assert resp.status_code == 400
+        assert "tts_generation" in resp.get_json()["message"]
+
+    def test_missing_article_path(self, app_and_registry):
+        app, _registry, _svc = app_and_registry
+        with app.test_client() as client:
+            resp = client.post("/api/article/tts", json={})
+        assert resp.status_code == 400
+
+    def test_sync_path_writes_frontmatter(self, app_and_registry):
+        """socketio=None 时走同步路径并写回 frontmatter。"""
+        app, registry, svc = app_and_registry
+        stub = MagicMock()
+        stub.Generate.return_value = iter(_make_tts_responses())
+        registry.plugin_manager.find_plugin_with_capability.return_value = {
+            "name": "tts-gen"
+        }
+        registry.plugin_manager.get_tts_generator_stub.return_value = stub
+
+        with app.test_client() as client:
+            resp = client.post(
+                "/api/article/tts",
+                json={"article_path": "post/demo/index.md"},
+            )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["pending"] is False
+        # 验证写回
+        _ok, _body, fm, _ = svc.read_file_with_frontmatter("post/demo/index.md")
+        assert fm[FM_AUDIO] == "https://r2.example.com/a.mp3"
+
+
+class TestStatusRoute:
+    def test_available_true(self, app_and_registry):
+        app, registry, _svc = app_and_registry
+        registry.plugin_manager.find_plugin_with_capability.return_value = {
+            "name": "tts-gen"
+        }
+        registry.plugin_manager.get_config_schema.return_value = {}
+        with app.test_client() as client:
+            resp = client.get("/api/article/tts/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["available"] is True
+        assert data["plugin"] == "tts-gen"
+
+    def test_available_false_when_no_plugin(self, app_and_registry):
+        app, registry, _svc = app_and_registry
+        registry.plugin_manager.find_plugin_with_capability.return_value = None
+        with app.test_client() as client:
+            resp = client.get("/api/article/tts/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["available"] is False
+
+
+class TestDeleteRoute:
+    def test_delete_clears_frontmatter(self, app_and_registry):
+        app, registry, svc = app_and_registry
+        # 先写入一个 audio 字段
+        _ok, body, fm, _ = svc.read_file_with_frontmatter("post/demo/index.md")
+        fm[FM_AUDIO] = "https://r2.example.com/old.mp3"
+        fm[FM_AUDIO_ID] = "key-old"
+        svc.save_file("post/demo/index.md", body, frontmatter_data=fm)
+
+        stub = MagicMock()
+        registry.plugin_manager.find_plugin_with_capability.return_value = {
+            "name": "tts-gen"
+        }
+        registry.plugin_manager.get_tts_generator_stub.return_value = stub
+
+        with app.test_client() as client:
+            resp = client.delete(
+                "/api/article/tts",
+                json={"article_path": "post/demo/index.md"},
+            )
+        assert resp.status_code == 200
+        _ok, _body, fm2, _ = svc.read_file_with_frontmatter("post/demo/index.md")
+        assert FM_AUDIO not in fm2
+        assert FM_AUDIO_ID not in fm2
+        # 插件被通知删除
+        stub.Delete.assert_called_once()


### PR DESCRIPTION
## 概述

在既有 gRPC 子进程插件系统上新增 `tts_generation` 能力，让用户能给博客文章生成语音播报。沿用 `add-plugin-system` 的架构，与 `image_upload` 完全对称：host 端只扩展协议/能力路由/文章集成层，实际的语音合成与托管放在闭源 Go 插件（独立私有仓库 [sun-praise/tts-gen-plugin](https://github.com/sun-praise/tts-gen-plugin)）。

配套插件已发布：https://github.com/sun-praise/tts-gen-plugin/releases/tag/v0.1.0

## 改动

**协议（向后兼容）**
- `proto/plugin.proto`：新增可选服务 `TTSGenerator`（`Generate` 服务端流式 + `Delete`）及 `TTSRequest`/`TTSResponse`(`oneof payload`)/`TTSProgress`/`TTSResult` 等消息
- 重新生成 Python 桩（`grpcio-tools`），已修正为相对导入；`ImageUploader` 不受影响，`protocol_version` 维持 `"1"`

**Host 端**
- `services/plugin_manager.py`：`get_tts_generator_stub()` + 通用 `find_plugin_with_capability()`（顺手把 `image_routes.py` 内联的能力查找循环抽出来复用）
- `routes/plugin_routes.py`：TTS 能力代理 `POST /api/plugins/<name>/tts/generate`（流式进度经 Socket.IO 转发）、`DELETE /api/plugins/<name>/tts/<audio_id>`；`register_plugin_routes` 新增可选 `socketio` 参数
- `routes/tts_routes.py`（新）：`POST /api/article/tts`（读正文→后台任务→乐观锁写回 frontmatter `audio`）、`DELETE /api/article/tts`、`GET /api/article/tts/status`。复刻 `article_import_service` 的后台任务 + `tts.progress/done/failed/conflict` 事件模式
- `app.py`：注册 tts 蓝图，向 plugin routes 注入 socketio

**前端**
- `Editor.tsx`：「生成语音播报」按钮（耳机图标，仅 TTS 可用时显示）+ 参数面板（音色/语速）+ 进度条 + 内联 `<audio>` 播放器 + 删除；基于 `useSocket` 监听 `tts.*` 事件
- `utils/api.ts`：`getTTSStatus`/`generateArticleTTS`/`deleteArticleTTS`

**测试**
- `tests/test_tts_routes.py`（10 例）：成功写回 frontmatter、无插件 400、插件失败、乐观锁冲突、同步路径、删除
- `tests/test_plugin_manager.py`：补 `get_tts_generator_stub` / `find_plugin_with_capability` 用例

## 验证
- `uv run pytest` → **400 passed**
- `uv run ruff check` → clean
- `tsc --noEmit` + `vite build` → ok
- Go 插件 `go test ./...` 通过（见独立仓库）

## 设计要点（详见 openspec/changes/add-tts-plugin/design.md）
1. **能力解耦对称**：插件「生成+托管」一体返回公网 URL，host 不碰音频二进制、不感知 MiMo/R2
2. **长任务**：gRPC 服务端流 + Socket.IO 转发，HTTP 立即返回 `event_scope`
3. **乐观锁写回**：复用 `save_file(expected_mtime)`，冲突走 `tts.conflict` 不覆盖
4. **无插件降级**：前端按 `/api/article/tts/status` 显隐按钮

## 破坏性变更
无。既有 `image_upload` 流程与 API 不受影响。

## Non-Goals
- 自动下载/签名校验安装（host 当前本就是手动安装，保持一致）
- 前台 Hugo 主题的 `<audio>` 渲染（仅约定 `audio:` frontmatter 字段）
- 音色设计/复刻 UI（V1 用预设音色 + 语速）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added article text-to-speech (TTS) in the editor, including voice selection, playback speed, progress updates, audio playback, regeneration, and deletion.
  * Introduced backend TTS endpoints for status, generation, and deletion, with real-time Socket.IO progress and optimistic-lock conflict handling.
* **Documentation**
  * Added design/proposal/spec and task documentation for the TTS generation plugin capability and end-to-end flow.
* **Tests**
  * Added unit tests covering TTS status, generation success/failure, progress/done events, conflict behavior, and deletion/frontmatter updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->